### PR TITLE
release: v1.2.7

### DIFF
--- a/apps/web/src/components/Dialog/GlobalMsg.tsx
+++ b/apps/web/src/components/Dialog/GlobalMsg.tsx
@@ -75,7 +75,7 @@ export const GlobalMsg = ({ setIsOpen, message, ...rest }: Props) => {
                   })}
                 </p>
               </div>
-              <p className='font-light mt-1 break-words max-w-[300px]'>
+              <p className='font-light mt-1 break-words whitespace-pre-wrap max-w-[300px]'>
                 {message?.content}
               </p>
               <p className='text-secondary-400 text-sm mt-4'>

--- a/apps/web/src/components/FeedAdContainer.tsx
+++ b/apps/web/src/components/FeedAdContainer.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect } from 'react';
+
+interface Props {
+  slotId: string;
+  className?: string;
+}
+
+const AdContainer = ({ slotId, className }: Props) => {
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      if (typeof window !== 'undefined') {
+        (window.adsbygoogle = window.adsbygoogle || []).push({});
+      }
+    }
+  }, []);
+
+  return (
+    <div className={className}>
+      <ins
+        className='adsbygoogle block'
+        data-ad-client='ca-pub-4274133898976040'
+        data-ad-layout-key="-il+e-1e-2w+ap"
+        data-ad-slot={slotId}
+        data-ad-format='fluid'
+      />
+    </div>
+  );
+};
+
+export default AdContainer;

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -61,7 +61,7 @@ export const Footer = () => {
           rel='noreferrer noopener'
           className='text-sm font-medium text-gray-500 hover:underline md:text-base'
         >
-          OMSIMOS© 2023
+          OMSIMOS© 2024
         </a>
       </div>
     </Container>

--- a/apps/web/src/components/GlobalPost.tsx
+++ b/apps/web/src/components/GlobalPost.tsx
@@ -53,7 +53,7 @@ export const GlobalPost = ({ message }: { message?: GlobalMessage }) => {
                 })}
               </p>
             </div>
-            <p className='font-light mt-1 break-words max-w-[350px]'>
+            <p className='font-light mt-1 break-words whitespace-pre-wrap max-w-[350px]'>
               {message?.content}
             </p>
           </div>

--- a/apps/web/src/pages/api/graphql.ts
+++ b/apps/web/src/pages/api/graphql.ts
@@ -9,6 +9,7 @@ import { buildSchema } from 'type-graphql';
 import prisma from '@/lib/db';
 import { UserResolver } from '@/schema/user';
 import { MessageResolver } from '@/schema/message';
+import { GlobalMessageResolver } from '@/schema/global-message';
 
 export interface TContext {
   prisma: typeof prisma;
@@ -17,7 +18,7 @@ export interface TContext {
 }
 
 const schema = await buildSchema({
-  resolvers: [UserResolver, MessageResolver],
+  resolvers: [UserResolver, MessageResolver, GlobalMessageResolver],
 });
 
 const server = new ApolloServer({

--- a/apps/web/src/pages/global.tsx
+++ b/apps/web/src/pages/global.tsx
@@ -16,6 +16,9 @@ import type { NextPageWithLayout } from '..';
 const AdContainer = dynamic(() => import('@/components/AdContainer'), {
   ssr: false,
 });
+const FeedAdContainer = dynamic(() => import('@/components/FeedAdContainer'), {
+  ssr: false,
+});
 
 const Global: NextPageWithLayout = () => {
   const [sendGlobalModal, setSendGlobalModal] = useState(false);
@@ -113,6 +116,8 @@ const Global: NextPageWithLayout = () => {
               {messages?.map((m) => (
                 <GlobalPost message={m} key={m?.id} />
               ))}
+
+              <FeedAdContainer slotId='1966757556' className='my-4' />
             </div>
 
             <Container className='grid place-items-center mt-12'>
@@ -134,8 +139,6 @@ const Global: NextPageWithLayout = () => {
                 )
               )}
             </Container>
-
-            <AdContainer slotId='2048259127' className='my-4' />
           </>
         )}
 

--- a/apps/web/src/schema/global-message/global-message.resolvers.ts
+++ b/apps/web/src/schema/global-message/global-message.resolvers.ts
@@ -1,0 +1,140 @@
+import {
+  Resolver,
+  Query,
+  Mutation,
+  Ctx,
+  Arg,
+  ID,
+  Directive,
+} from 'type-graphql';
+
+import type { TContext } from '@/pages/api/graphql';
+import {
+  GlobalMessagesData,
+  SendGlobalMessage,
+  SendGlobalMessageInput,
+  GlobalMessage,
+} from './global-message.types';
+
+@Resolver()
+export class GlobalMessageResolver {
+  @Directive('@cacheControl(maxAge: 240)')
+  @Query(() => GlobalMessagesData, { nullable: true })
+  async getGlobalMessages(
+    @Arg('cursorId', () => ID, { nullable: true }) cursorId: string,
+    @Ctx() { prisma }: TContext
+  ): Promise<GlobalMessagesData | null> {
+    try {
+      const messages = await prisma.globalMessage.findMany({
+        orderBy: { updatedAt: 'desc' },
+        take: 10,
+        include: {
+          user: {
+            select: {
+              id: true,
+              username: true,
+              image: true,
+            },
+          },
+        },
+        ...(cursorId && {
+          skip: 1,
+          cursor: {
+            id: cursorId,
+          },
+        }),
+      });
+
+      if (messages.length === 0) {
+        return {
+          data: [],
+          cursorId: null,
+        };
+      }
+
+      return {
+        data: messages,
+        cursorId: messages[messages.length - 1].id,
+      };
+    } catch (err) {
+      console.error(err);
+      throw err;
+    }
+  }
+
+  @Directive('@cacheControl(maxAge: 60)')
+  @Mutation(() => SendGlobalMessage)
+  async sendGlobalMessage(
+    @Arg('input', () => SendGlobalMessageInput)
+    { content, isAnonymous }: SendGlobalMessageInput,
+    @Ctx() { prisma, id }: TContext
+  ): Promise<SendGlobalMessage> {
+    let latestMessage: Omit<GlobalMessage, 'user'> | null;
+
+    try {
+      latestMessage = await prisma.globalMessage.findFirst({
+        where: { userId: id },
+        orderBy: { updatedAt: 'desc' },
+      });
+
+      if (latestMessage?.updatedAt) {
+        const diff = new Date().getTime() - latestMessage.updatedAt.getTime();
+
+        if (diff < 1000 * 60 && process.env.NODE_ENV !== 'development') {
+          return {
+            error: 'You can only send a message once every 1 minute.',
+          };
+        }
+      }
+    } catch (err) {
+      console.error(err);
+      throw err;
+    }
+
+    try {
+      let message: GlobalMessage;
+
+      if (!latestMessage) {
+        message = await prisma.globalMessage.create({
+          data: {
+            content,
+            isAnonymous,
+            user: id ? { connect: { id } } : undefined,
+          },
+          include: {
+            user: {
+              select: {
+                id: true,
+                username: true,
+                image: true,
+              },
+            },
+          },
+        });
+      } else {
+        message = await prisma.globalMessage.update({
+          where: { id: latestMessage?.id },
+          data: {
+            content,
+            isAnonymous,
+            user: id ? { connect: { id } } : undefined,
+          },
+          include: {
+            user: {
+              select: {
+                id: true,
+                username: true,
+                image: true,
+              },
+            },
+          },
+        });
+      }
+
+      return { data: message };
+    } catch (err) {
+      console.error(err);
+      throw err;
+    }
+  }
+}

--- a/apps/web/src/schema/global-message/global-message.types.ts
+++ b/apps/web/src/schema/global-message/global-message.types.ts
@@ -1,0 +1,64 @@
+import { ObjectType, Field, ID, InputType, Directive } from 'type-graphql';
+import { MaxLength, MinLength, IsNotEmpty } from 'class-validator';
+import { ErrorResponse } from '../types';
+
+@ObjectType()
+class GlobalMessageUser {
+  @Field(() => ID)
+  id: string;
+
+  @Field(() => String, { nullable: true })
+  username: string | null;
+
+  @Field(() => String, { nullable: true })
+  image: string | null;
+}
+
+@Directive('@cacheControl(maxAge: 86400)')
+@ObjectType()
+export class GlobalMessage {
+  @Field(() => ID)
+  id: string;
+
+  @Field(() => String)
+  content: string;
+
+  @Field(() => Boolean)
+  isAnonymous: boolean;
+
+  @Field(() => Date)
+  createdAt: Date;
+
+  @Field(() => Date)
+  updatedAt: Date;
+
+  @Field(() => GlobalMessageUser, { nullable: true })
+  user: GlobalMessageUser | null;
+}
+
+@ObjectType()
+export class GlobalMessagesData {
+  @Field(() => [GlobalMessage])
+  data: GlobalMessage[];
+
+  @Field(() => String, { nullable: true })
+  cursorId: string | null;
+}
+
+@ObjectType()
+export class SendGlobalMessage extends ErrorResponse {
+  @Field(() => GlobalMessage, { nullable: true })
+  data?: GlobalMessage | null;
+}
+
+@InputType()
+export class SendGlobalMessageInput {
+  @IsNotEmpty()
+  @MinLength(1)
+  @MaxLength(500)
+  @Field(() => String)
+  content: string;
+
+  @Field(() => Boolean)
+  isAnonymous: boolean;
+}

--- a/apps/web/src/schema/global-message/index.ts
+++ b/apps/web/src/schema/global-message/index.ts
@@ -1,0 +1,2 @@
+export * from './global-message.types'
+export * from './global-message.resolvers'

--- a/apps/web/src/schema/message/message.resolvers.ts
+++ b/apps/web/src/schema/message/message.resolvers.ts
@@ -1,150 +1,16 @@
 /* eslint-disable no-console */
-import {
-  Resolver,
-  Query,
-  Mutation,
-  Ctx,
-  Arg,
-  ID,
-  Directive,
-} from 'type-graphql';
+import { Resolver, Query, Mutation, Ctx, Arg, ID } from 'type-graphql';
 
 import type { TContext } from '@/pages/api/graphql';
-import {
-  GlobalMessagesData,
-  SendGlobalMessage,
-  SendGlobalMessageInput,
-  SendMessageInput,
-  MessagesData,
-  GlobalMessage,
-} from './message.types';
+
 import { ErrorResponse } from '../types';
+import { SendMessageInput, MessagesData } from './message.types';
 
 @Resolver()
 export class MessageResolver {
   @Query(() => ErrorResponse)
   hello(): ErrorResponse {
     return { error: 'hi' };
-  }
-
-  @Directive('@cacheControl(maxAge: 240)')
-  @Query(() => GlobalMessagesData, { nullable: true })
-  async getGlobalMessages(
-    @Arg('cursorId', () => ID, { nullable: true }) cursorId: string,
-    @Ctx() { prisma }: TContext
-  ): Promise<GlobalMessagesData | null> {
-    try {
-      const messages = await prisma.globalMessage.findMany({
-        orderBy: { updatedAt: 'desc' },
-        take: 10,
-        include: {
-          user: {
-            select: {
-              id: true,
-              username: true,
-              image: true,
-            },
-          },
-        },
-        ...(cursorId && {
-          skip: 1,
-          cursor: {
-            id: cursorId,
-          },
-        }),
-      });
-
-      if (messages.length === 0) {
-        return {
-          data: [],
-          cursorId: null,
-        };
-      }
-
-      return {
-        data: messages,
-        cursorId: messages[messages.length - 1].id,
-      };
-    } catch (err) {
-      console.error(err);
-      throw err;
-    }
-  }
-
-  @Directive('@cacheControl(maxAge: 60)')
-  @Mutation(() => SendGlobalMessage)
-  async sendGlobalMessage(
-    @Arg('input', () => SendGlobalMessageInput)
-    { content, isAnonymous }: SendGlobalMessageInput,
-    @Ctx() { prisma, id }: TContext
-  ): Promise<SendGlobalMessage> {
-    let latestMessage: Omit<GlobalMessage, 'user'> | null;
-
-    try {
-      latestMessage = await prisma.globalMessage.findFirst({
-        where: { userId: id },
-        orderBy: { updatedAt: 'desc' },
-      });
-
-      if (latestMessage?.updatedAt) {
-        const diff = new Date().getTime() - latestMessage.updatedAt.getTime();
-
-        if (diff < 1000 * 60 && process.env.NODE_ENV !== 'development') {
-          return {
-            error: 'You can only send a message once every 1 minute.',
-          };
-        }
-      }
-    } catch (err) {
-      console.error(err);
-      throw err;
-    }
-
-    try {
-      let message: GlobalMessage;
-
-      if (!latestMessage) {
-        message = await prisma.globalMessage.create({
-          data: {
-            content,
-            isAnonymous,
-            user: id ? { connect: { id } } : undefined,
-          },
-          include: {
-            user: {
-              select: {
-                id: true,
-                username: true,
-                image: true,
-              },
-            },
-          },
-        });
-      } else {
-        message = await prisma.globalMessage.update({
-          where: { id: latestMessage?.id },
-          data: {
-            content,
-            isAnonymous,
-            user: id ? { connect: { id } } : undefined,
-          },
-          include: {
-            user: {
-              select: {
-                id: true,
-                username: true,
-                image: true,
-              },
-            },
-          },
-        });
-      }
-
-      return { data: message };
-    } catch (err) {
-      console.error(err);
-      throw err;
-    }
   }
 
   @Query(() => MessagesData, { nullable: true })

--- a/apps/web/src/schema/message/message.types.ts
+++ b/apps/web/src/schema/message/message.types.ts
@@ -1,55 +1,5 @@
 import { ObjectType, Field, ID, InputType, Directive } from 'type-graphql';
 import { MaxLength, MinLength, IsNotEmpty } from 'class-validator';
-import { ErrorResponse } from '../types';
-
-@ObjectType()
-class GlobalMessageUser {
-  @Field(() => ID)
-  id: string;
-
-  @Field(() => String, { nullable: true })
-  username: string | null;
-
-  @Field(() => String, { nullable: true })
-  image: string | null;
-}
-
-@Directive('@cacheControl(maxAge: 86400)')
-@ObjectType()
-export class GlobalMessage {
-  @Field(() => ID)
-  id: string;
-
-  @Field(() => String)
-  content: string;
-
-  @Field(() => Boolean)
-  isAnonymous: boolean;
-
-  @Field(() => Date)
-  createdAt: Date;
-
-  @Field(() => Date)
-  updatedAt: Date;
-
-  @Field(() => GlobalMessageUser, { nullable: true })
-  user: GlobalMessageUser | null;
-}
-
-@ObjectType()
-export class GlobalMessagesData {
-  @Field(() => [GlobalMessage])
-  data: GlobalMessage[];
-
-  @Field(() => String, { nullable: true })
-  cursorId: string | null;
-}
-
-@ObjectType()
-export class SendGlobalMessage extends ErrorResponse {
-  @Field(() => GlobalMessage, { nullable: true })
-  data?: GlobalMessage | null;
-}
 
 @Directive('@cacheControl(maxAge: 86400)')
 @ObjectType()
@@ -106,16 +56,4 @@ export class SendMessageInput {
   @IsNotEmpty()
   @Field(() => String)
   receiverUsername: string;
-}
-
-@InputType()
-export class SendGlobalMessageInput {
-  @IsNotEmpty()
-  @MinLength(1)
-  @MaxLength(500)
-  @Field(() => String)
-  content: string;
-
-  @Field(() => Boolean)
-  isAnonymous: boolean;
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -74,8 +74,8 @@ model Message {
   receiverId       String
   receiver         User    @relation(name: "receivedMessages", fields: [receiverId], references: [id], onDelete: Cascade)
 
-  @@index([senderId, isOpened, createdAt(sort: Desc)])
-  @@index([receiverId, isOpened, createdAt(sort: Desc)])
+  @@index([senderId, createdAt(sort: Desc)])
+  @@index([receiverId, createdAt(sort: Desc)])
 }
 
 model GlobalMessage {
@@ -88,5 +88,5 @@ model GlobalMessage {
   userId String?
   user   User?   @relation(name: "sentGlobalMessages", fields: [userId], references: [id], onDelete: Cascade)
 
-  @@index([userId, isAnonymous, updatedAt(sort: Desc)])
+  @@index([userId, updatedAt(sort: Desc)])
 }


### PR DESCRIPTION
- Move `global messages` queries and mutations to a separate resolver
- Remove unused fields in schema indexes
- Add whitespace pre wrap in global message content
- Update year in footer (2024)