### PR TITLE
perf(web): error-tracking coverage and hot-path optimization pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,23 @@ any that are empty.
 - **Deprecated** — features marked for removal.
 - **Removed** — features removed.
 
+## [7.6.3] - 2026-09-01
+
+### Fixed
+
+- Copying or sharing a profile or post link now confirms only after the copy or share actually succeeds, and closing the share sheet without sharing is no longer treated as an error.
+
+### Performance & Cost
+
+- Liking and unliking posts completes noticeably faster.
+- The feed, post pages, comments, and notes load faster when signed in, and long feeds stay smooth while liking or reposting.
+- Group pages show the member list sooner after opening.
+- Opening the inbox and message threads takes less server time, and background cleanup jobs no longer scan whole tables — lower database usage overall.
+
+### Security & Privacy
+
+- Hardened cached post responses against crafted links.
+
 ## [7.6.2] - 2026-08-26
 
 ### Fixed
@@ -949,6 +966,7 @@ Turso query cost, and a set of audit-driven correctness and security fixes.
 - Stopped logging raw errors that could contain usernames or token internals.
 - Added a daily cron that prunes expired sessions.
 
+[7.6.3]: https://github.com/omsimos/umamin/compare/v7.6.2...v7.6.3
 [7.6.2]: https://github.com/omsimos/umamin/compare/v7.6.1...v7.6.2
 [7.6.1]: https://github.com/omsimos/umamin/compare/v7.6.0...v7.6.1
 [7.6.0]: https://github.com/omsimos/umamin/compare/v7.5.0...v7.6.0

--- a/apps/web/src/api/actions/auth.ts
+++ b/apps/web/src/api/actions/auth.ts
@@ -27,6 +27,7 @@ import {
 import { extractClientIp } from "../../server-lib/ip";
 import { isIpDenied } from "../../server-lib/ip-denylist";
 import { AURA_POINTS, isAuraEligibleActor } from "../../server-lib/points";
+import { captureRequestException } from "../../server-lib/posthog";
 import { createR2 } from "../../server-lib/r2";
 import { checkRateLimit, RATE_LIMIT_ERROR } from "../../server-lib/ratelimit";
 import { registerSchema } from "../../server-lib/schema";
@@ -130,6 +131,7 @@ export async function loginHandler(c: AppContext): Promise<Response> {
     setSessionCookie(c, token, new Date(session.expiresAt));
   } catch (err) {
     console.error("Login error:", formatErrorChain(err));
+    captureRequestException(c, err, { properties: { action: "login" } });
     return c.json({ error: "An unexpected error occurred" });
   }
 
@@ -193,6 +195,8 @@ export async function signupHandler(c: AppContext): Promise<Response> {
         return c.json({ error: "Username already exists" });
       }
     }
+    console.error("Signup error:", formatErrorChain(err));
+    captureRequestException(c, err, { properties: { action: "signup" } });
     return c.json({ error: "An unexpected error occurred" });
   }
 
@@ -397,6 +401,10 @@ export async function deleteAccountHandler(c: AppContext): Promise<Response> {
     }
   } catch (err) {
     console.error("Account deletion cleanup failed:", formatErrorChain(err));
+    captureRequestException(c, err, {
+      distinctId: user.id,
+      properties: { action: "deleteAccount" },
+    });
   }
 
   return c.json({ redirect: "/login" });

--- a/apps/web/src/api/actions/post.ts
+++ b/apps/web/src/api/actions/post.ts
@@ -21,7 +21,13 @@ import { hasPlusPerks } from "../../server-lib/content";
 import { getPostById } from "../../server-lib/data";
 import { isModerator } from "../../server-lib/moderation";
 import { notify } from "../../server-lib/notifications";
-import { AURA_POINTS, awardAura, reverseAura } from "../../server-lib/points";
+import {
+  AURA_POINTS,
+  auraAwardStatement,
+  auraReverseStatement,
+  awardAura,
+  reverseAura,
+} from "../../server-lib/points";
 import {
   POLL_DURATIONS,
   POLL_ENDED_ERROR,
@@ -40,6 +46,12 @@ import { ctxDb, defer } from "./_shared";
 // reads hit Turso directly (read-your-writes), public reads cache at route level.
 // Per-write hot-feed rank refresh is likewise a no-op now — the */5 cron
 // recomputes the ranking (≤5min lag accepted, plan feed-rank note).
+
+// Runs the statement only if the PREVIOUS statement of the same db.batch
+// changed a row: changes() reads the preceding statement's count on the shared
+// connection, which is how a batch replaces an interactive transaction's
+// JS-side branching. test/batch-changes.test.ts pins those semantics.
+const PREV_CHANGED = sql`(SELECT changes()) > 0`;
 
 const createPostSchema = z
   .object({
@@ -441,41 +453,46 @@ export const addLikeHandler = action(
   },
   async ({ postId }, { session, user, c }) => {
     const db = ctxDb(c);
-    let likedPost: { authorId: string; content: string } | undefined;
 
-    const result = await db.transaction(async (tx) => {
-      const inserted = await tx
+    // One round trip instead of four (BEGIN+insert, update, award, COMMIT):
+    // each statement gates on PREV_CHANGED, so the count bump lands only when
+    // the like row was really inserted and the award only when the bump landed
+    // — a bump that matched no row reports changes() = 0 in turn.
+    const award = auraAwardStatement(
+      db,
+      {
+        beneficiary: { postId },
+        actorId: session.userId,
+        actorCreatedAt: user?.createdAt,
+        delta: AURA_POINTS.like,
+      },
+      PREV_CHANGED,
+    );
+    const statements = [
+      db
         .insert(postLikeTable)
         .values({ postId, userId: session.userId })
         .onConflictDoNothing()
-        .returning({ id: postLikeTable.id });
-
-      if (inserted.length === 0) {
-        return { success: true, alreadyLiked: true } as const;
-      }
-
-      const [updated] = await tx
+        .returning({ id: postLikeTable.id }),
+      db
         .update(postTable)
         .set({ likeCount: sql`${postTable.likeCount} + 1` })
-        .where(eq(postTable.id, postId))
+        .where(and(eq(postTable.id, postId), PREV_CHANGED))
         .returning({
           authorId: postTable.authorId,
           content: postTable.content,
-        });
+        }),
+    ] as const;
 
-      likedPost = updated;
+    const [inserted, bumped] = award
+      ? await db.batch([...statements, award])
+      : await db.batch(statements);
 
-      if (updated) {
-        await awardAura(tx, {
-          beneficiaryId: updated.authorId,
-          actorId: session.userId,
-          actorCreatedAt: user?.createdAt,
-          delta: AURA_POINTS.like,
-        });
-      }
+    if (inserted.length === 0) {
+      return { success: true, alreadyLiked: true } as const;
+    }
 
-      return { success: true } as const;
-    });
+    const likedPost = bumped[0];
 
     if (likedPost) {
       await notify(
@@ -489,7 +506,7 @@ export const addLikeHandler = action(
         },
       );
     }
-    return result;
+    return { success: true } as const;
   },
 );
 
@@ -597,8 +614,19 @@ export const removeLikeHandler = action(
   },
   async ({ postId }, { session, user, c }) => {
     const db = ctxDb(c);
-    return db.transaction(async (tx) => {
-      const removed = await tx
+
+    const reverse = auraReverseStatement(
+      db,
+      {
+        beneficiary: { postId },
+        actorId: session.userId,
+        actorCreatedAt: user?.createdAt,
+        delta: AURA_POINTS.like,
+      },
+      PREV_CHANGED,
+    );
+    const statements = [
+      db
         .delete(postLikeTable)
         .where(
           and(
@@ -606,31 +634,25 @@ export const removeLikeHandler = action(
             eq(postLikeTable.userId, session.userId),
           ),
         )
-        .returning({ id: postLikeTable.id });
-
-      if (removed.length === 0) {
-        return { success: true, alreadyRemoved: true };
-      }
-
-      const [updated] = await tx
+        .returning({ id: postLikeTable.id }),
+      db
         .update(postTable)
         .set({
           likeCount: sql`CASE WHEN ${postTable.likeCount} > 0 THEN ${postTable.likeCount} - 1 ELSE 0 END`,
         })
-        .where(eq(postTable.id, postId))
-        .returning({ authorId: postTable.authorId });
+        .where(and(eq(postTable.id, postId), PREV_CHANGED))
+        .returning({ authorId: postTable.authorId }),
+    ] as const;
 
-      if (updated) {
-        await reverseAura(tx, {
-          beneficiaryId: updated.authorId,
-          actorId: session.userId,
-          actorCreatedAt: user?.createdAt,
-          delta: AURA_POINTS.like,
-        });
-      }
+    const [removed] = reverse
+      ? await db.batch([...statements, reverse])
+      : await db.batch(statements);
 
-      return { success: true };
-    });
+    if (removed.length === 0) {
+      return { success: true, alreadyRemoved: true };
+    }
+
+    return { success: true };
   },
 );
 

--- a/apps/web/src/api/actions/user.ts
+++ b/apps/web/src/api/actions/user.ts
@@ -21,6 +21,7 @@ import {
 import { fetchMusicMeta } from "../../server-lib/music-meta";
 import { notify } from "../../server-lib/notifications";
 import { AURA_POINTS, awardAura, reverseAura } from "../../server-lib/points";
+import { captureRequestException } from "../../server-lib/posthog";
 import { createR2 } from "../../server-lib/r2";
 import { idSchema } from "../../server-lib/schema";
 import {
@@ -87,6 +88,10 @@ export const getUserProfileHandler = action(
       return await getUserProfileData(ctxDb(c), username, session?.userId);
     } catch (err) {
       console.error("Error fetching user profile:", formatErrorChain(err));
+      captureRequestException(c, err, {
+        distinctId: session?.userId,
+        properties: { action: "getUserProfile" },
+      });
       return null;
     }
   },

--- a/apps/web/src/api/auth/google.ts
+++ b/apps/web/src/api/auth/google.ts
@@ -19,9 +19,11 @@ import {
   GOOGLE_OAUTH_STATE_COOKIE_NAME,
 } from "../../server-lib/cookies";
 import { getDb } from "../../server-lib/db";
+import { formatErrorChain } from "../../server-lib/errors";
 import { extractClientIp } from "../../server-lib/ip";
 import { isIpDenied } from "../../server-lib/ip-denylist";
 import { buildGoogle } from "../../server-lib/oauth";
+import { captureRequestException } from "../../server-lib/posthog";
 import { checkRateLimit } from "../../server-lib/ratelimit";
 import {
   createSession,
@@ -248,10 +250,14 @@ export const googleAuthApp = new Hono<AppBindings>()
 
       return c.redirect("/inbox", 302);
     } catch (err) {
-      console.error("oauth_callback_failed");
+      console.error("oauth_callback_failed", formatErrorChain(err));
+      // A provider-side OAuth rejection is a user/provider outcome, not a bug.
       if (err instanceof OAuth2RequestError) {
         return c.body(null, 400);
       }
+      captureRequestException(c, err, {
+        properties: { oauth: "google", intent },
+      });
       return c.body(null, 500);
     }
   });

--- a/apps/web/src/api/routes/_shared.ts
+++ b/apps/web/src/api/routes/_shared.ts
@@ -28,7 +28,10 @@ export function readsSessionContext(): MiddlewareHandler<AppBindings> {
   return async (c, next) => {
     let cached: Promise<ResolvedSession> | undefined;
     c.set("getSession", () => {
-      cached ??= resolveSession(c, resolveDb(c.env));
+      cached ??= resolveSession(c, resolveDb(c.env)).then((resolved) => {
+        if (resolved.session) c.set("resolvedUserId", resolved.session.userId);
+        return resolved;
+      });
       return cached;
     });
     await next();

--- a/apps/web/src/api/routes/notes.ts
+++ b/apps/web/src/api/routes/notes.ts
@@ -1,18 +1,39 @@
 import { Hono } from "hono";
+import type { NotesResponse } from "../../lib/types";
 import type { AppBindings } from "../../server-lib/context";
 import { getCurrentNoteData, getNotesPage } from "../../server-lib/data";
 import { UNAUTHORIZED_ERROR } from "../../server-lib/errors";
-import { withPrivateRead } from "../../server-lib/read-route";
+import {
+  getCachedPublicPayload,
+  withPrivateRead,
+} from "../../server-lib/read-route";
 import { getSessionFrom, resolveDb } from "./_shared";
+import { PUBLIC_BROWSER_MAX_AGE, PUBLIC_NOTES_MAX_AGE } from "./public";
 
 export const notesRoutes = new Hono<AppBindings>()
   .get(
     "/notes",
+    // Same shared-entry-plus-overlay split as /posts (see api/routes/posts.ts):
+    // the notes page itself is viewer-independent, so it is read through
+    // /public/notes' own Cache API entry and only the overlay stays per-viewer.
     withPrivateRead("fetching notes", async (c) => {
+      const cursor = c.req.query("cursor") ?? null;
       const { session } = await getSessionFrom(c);
-      return getNotesPage(resolveDb(c.env), {
-        cursor: c.req.query("cursor") ?? null,
+      const db = resolveDb(c.env);
+
+      const publicData = await getCachedPublicPayload<NotesResponse>(
+        c,
+        "/public/notes",
+        { cursor },
+        PUBLIC_NOTES_MAX_AGE,
+        PUBLIC_BROWSER_MAX_AGE,
+        () => getNotesPage(db, { cursor }),
+      );
+
+      return getNotesPage(db, {
+        cursor,
         viewerId: session?.userId,
+        publicData,
       });
     }),
   )

--- a/apps/web/src/api/routes/posts.ts
+++ b/apps/web/src/api/routes/posts.ts
@@ -1,5 +1,10 @@
 import { Hono } from "hono";
 import { normalizeFeedSort } from "../../lib/feed-sort";
+import type {
+  CommentsResponse,
+  FeedResponse,
+  PostResponse,
+} from "../../lib/types";
 import type { AppBindings } from "../../server-lib/context";
 import {
   getPostById,
@@ -7,11 +12,32 @@ import {
   getPostsPage,
 } from "../../server-lib/data";
 import { UNAUTHORIZED_ERROR } from "../../server-lib/errors";
-import { withPrivateRead } from "../../server-lib/read-route";
+import {
+  getCachedPublicPayload,
+  withPrivateRead,
+} from "../../server-lib/read-route";
 import { getSessionFrom, resolveDb } from "./_shared";
+import {
+  PUBLIC_BROWSER_MAX_AGE,
+  PUBLIC_COMMENTS_MAX_AGE,
+  PUBLIC_POST_MAX_AGE,
+  PUBLIC_POSTS_MAX_AGE,
+} from "./public";
 
 // Private (per-viewer) post reads. `following` requires a session; anonymous
 // feed reads live behind /public/posts.
+//
+// Every other sort/page here is the SAME viewer-independent payload
+// /public/posts serves, plus a thin viewer overlay — so the shared part is read
+// through the public route's own Cache API entry (getCachedPublicPayload) and
+// only the overlay hits Turso on a warm entry. Signed-in reads therefore see
+// counts/content up to the public TTL stale, the window anonymous readers
+// already accept; own actions stay instant via the client's optimistic patches
+// and the overlay (isLiked/isReposted/blocks) is always fresh.
+//
+// The `id` segment is re-encoded into the cache key: Hono percent-DECODES route
+// params, so a raw `../…` id would resolve the key URL onto another route's
+// entry.
 export const postsRoutes = new Hono<AppBindings>()
   .get(
     "/posts",
@@ -19,25 +45,59 @@ export const postsRoutes = new Hono<AppBindings>()
       const cursor = c.req.query("cursor") ?? null;
       const sort = normalizeFeedSort(c.req.query("sort"));
       const { session } = await getSessionFrom(c);
+      const db = resolveDb(c.env);
 
-      if (sort === "following" && !session) {
-        return Response.json({ error: UNAUTHORIZED_ERROR }, { status: 401 });
+      if (sort === "following") {
+        if (!session) {
+          return Response.json({ error: UNAUTHORIZED_ERROR }, { status: 401 });
+        }
+        // Per-viewer by nature — no public twin, never cached.
+        return getPostsPage(db, c.env.KV, {
+          cursor,
+          sort,
+          viewerId: session.userId,
+        });
       }
 
-      return getPostsPage(resolveDb(c.env), c.env.KV, {
+      const publicData = await getCachedPublicPayload<FeedResponse>(
+        c,
+        "/public/posts",
+        { sort, cursor },
+        PUBLIC_POSTS_MAX_AGE,
+        PUBLIC_BROWSER_MAX_AGE,
+        () => getPostsPage(db, c.env.KV, { cursor, sort }),
+      );
+
+      return getPostsPage(db, c.env.KV, {
         cursor,
         sort,
         viewerId: session?.userId,
+        publicData,
       });
     }),
   )
   .get(
     "/posts/:id",
     withPrivateRead("fetching post", async (c) => {
+      const postId = c.req.param("id") ?? "";
       const { session } = await getSessionFrom(c);
-      const result = await getPostById(resolveDb(c.env), {
-        postId: c.req.param("id") ?? "",
+      const db = resolveDb(c.env);
+
+      const publicPost = await getCachedPublicPayload<PostResponse>(
+        c,
+        `/public/posts/${encodeURIComponent(postId)}`,
+        {},
+        PUBLIC_POST_MAX_AGE,
+        PUBLIC_BROWSER_MAX_AGE,
+        () => getPostById(db, { postId }),
+      );
+
+      if (!publicPost) return null;
+
+      const result = await getPostById(db, {
+        postId,
         viewerId: session?.userId,
+        publicPost,
       });
       return result ?? null;
     }),
@@ -45,11 +105,25 @@ export const postsRoutes = new Hono<AppBindings>()
   .get(
     "/posts/:id/comments",
     withPrivateRead("fetching comments", async (c) => {
+      const postId = c.req.param("id") ?? "";
+      const cursor = c.req.query("cursor") ?? null;
       const { session } = await getSessionFrom(c);
-      return getPostCommentsPage(resolveDb(c.env), {
-        postId: c.req.param("id") ?? "",
-        cursor: c.req.query("cursor") ?? null,
+      const db = resolveDb(c.env);
+
+      const publicData = await getCachedPublicPayload<CommentsResponse>(
+        c,
+        `/public/posts/${encodeURIComponent(postId)}/comments`,
+        { cursor },
+        PUBLIC_COMMENTS_MAX_AGE,
+        PUBLIC_BROWSER_MAX_AGE,
+        () => getPostCommentsPage(db, { postId, cursor }),
+      );
+
+      return getPostCommentsPage(db, {
+        postId,
+        cursor,
         viewerId: session?.userId,
+        publicData,
       });
     }),
   );

--- a/apps/web/src/api/routes/public.ts
+++ b/apps/web/src/api/routes/public.ts
@@ -17,6 +17,16 @@ import { formatUsername, resolveDb } from "./_shared";
 const notFound = () =>
   Response.json({ error: NOT_FOUND_ERROR }, { status: 404 });
 
+// TTLs for the four entries the PRIVATE routes also read and fill through
+// getCachedPublicPayload (api/routes/posts.ts, api/routes/notes.ts) so one
+// Turso fill serves signed-in and anonymous traffic alike. Both sides must
+// declare the same numbers, hence the shared constants.
+export const PUBLIC_POSTS_MAX_AGE = 180;
+export const PUBLIC_POST_MAX_AGE = 120;
+export const PUBLIC_COMMENTS_MAX_AGE = 120;
+export const PUBLIC_NOTES_MAX_AGE = 180;
+export const PUBLIC_BROWSER_MAX_AGE = 60;
+
 // Anonymous, CDN-cached (Cache API) reads. TTLs preserved from apps/www EXCEPT
 // the public profile: 7d → 300s (plan) — tag purge is gone, so a short TTL plus
 // own-device setQueryData covers freshness.
@@ -25,7 +35,7 @@ export const publicRoutes = new Hono<AppBindings>()
     "/public/posts",
     withPublicRead(
       "fetching public posts",
-      180,
+      PUBLIC_POSTS_MAX_AGE,
       async (req, env) => {
         const requestedSort = normalizeFeedSort(req.query("sort"));
         const sort =
@@ -35,7 +45,7 @@ export const publicRoutes = new Hono<AppBindings>()
           sort,
         });
       },
-      60,
+      PUBLIC_BROWSER_MAX_AGE,
       ["sort", "cursor"],
     ),
   )
@@ -43,13 +53,13 @@ export const publicRoutes = new Hono<AppBindings>()
     "/public/posts/:id/comments",
     withPublicRead(
       "fetching public comments",
-      120,
+      PUBLIC_COMMENTS_MAX_AGE,
       async (req, env) =>
         getPostCommentsPage(resolveDb(env), {
           postId: req.param("id") ?? "",
           cursor: req.query("cursor") ?? null,
         }),
-      60,
+      PUBLIC_BROWSER_MAX_AGE,
       ["cursor"],
     ),
   )
@@ -57,14 +67,14 @@ export const publicRoutes = new Hono<AppBindings>()
     "/public/posts/:id",
     withPublicRead(
       "fetching public post",
-      120,
+      PUBLIC_POST_MAX_AGE,
       async (req, env) => {
         const result = await getPostById(resolveDb(env), {
           postId: req.param("id") ?? "",
         });
         return result ?? notFound();
       },
-      60,
+      PUBLIC_BROWSER_MAX_AGE,
       [],
     ),
   )
@@ -72,10 +82,10 @@ export const publicRoutes = new Hono<AppBindings>()
     "/public/notes",
     withPublicRead(
       "fetching public notes",
-      180,
+      PUBLIC_NOTES_MAX_AGE,
       async (req, env) =>
         getNotesPage(resolveDb(env), { cursor: req.query("cursor") ?? null }),
-      60,
+      PUBLIC_BROWSER_MAX_AGE,
       ["cursor"],
     ),
   )

--- a/apps/web/src/api/webhooks.ts
+++ b/apps/web/src/api/webhooks.ts
@@ -4,6 +4,7 @@ import {
   type LemonSqueezyOrderEvent,
   verifyWebhookSignature,
 } from "../server-lib/lemonsqueezy";
+import { captureRequestException } from "../server-lib/posthog";
 import { recordProPurchase, refundProPurchase } from "../server-lib/pro";
 import { ctxDb } from "./actions/_shared";
 
@@ -28,6 +29,11 @@ export const webhooksApp = new Hono<AppBindings>().post(
       // Never accept an unverifiable payment event — 500 so a temporarily
       // missing secret becomes a retry, not a dropped grant.
       console.error("[pro] LEMONSQUEEZY_WEBHOOK_SECRET missing");
+      captureRequestException(
+        c,
+        new Error("lemonsqueezy webhook secret missing"),
+        { properties: { webhook: "lemonsqueezy" } },
+      );
       return c.json({ error: "not configured" }, 500);
     }
 
@@ -65,6 +71,17 @@ export const webhooksApp = new Hono<AppBindings>().post(
       console.error(
         `[pro] webhook for foreign store ${order.store_id}, expected ${storeId}`,
       );
+      captureRequestException(
+        c,
+        new Error("lemonsqueezy webhook for foreign store"),
+        {
+          properties: {
+            webhook: "lemonsqueezy",
+            orderId,
+            storeId: String(order.store_id),
+          },
+        },
+      );
       return c.json({ ok: true, skipped: "foreign store" });
     }
 
@@ -88,6 +105,11 @@ export const webhooksApp = new Hono<AppBindings>().post(
         // A purchase made outside the in-app checkout (e.g. a direct store
         // link) has no attribution — surface it for manual support handling.
         console.error(`[pro] order ${orderId} has no user_id custom data`);
+        captureRequestException(
+          c,
+          new Error("lemonsqueezy paid order unattributed"),
+          { properties: { webhook: "lemonsqueezy", orderId } },
+        );
         return c.json({ ok: true, skipped: "unattributed" });
       }
 

--- a/apps/web/src/components/ad-container.tsx
+++ b/apps/web/src/components/ad-container.tsx
@@ -5,6 +5,7 @@ import {
   type AdPlacement,
   adPlacements,
 } from "@/lib/ad-placements";
+import { captureException } from "@/lib/posthog";
 
 declare global {
   interface Window {
@@ -99,7 +100,7 @@ const AdContainer = ({ placement, className }: Props) => {
         (window.adsbygoogle = window.adsbygoogle || []).push({});
         pushedRef.current = true;
       } catch (err) {
-        console.log(err);
+        captureException(err, { source: "ads" });
         timeoutId = window.setTimeout(initializeAd, 250);
       }
     };

--- a/apps/web/src/components/copy-link.test.tsx
+++ b/apps/web/src/components/copy-link.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const toastSuccess = vi.fn();
@@ -38,13 +38,15 @@ describe("CopyLink", () => {
   //
   // fireEvent (not userEvent) so the component's navigator.clipboard stub isn't
   // clobbered by userEvent.setup()'s own clipboard override.
-  it("copies the full origin-qualified URL and confirms", () => {
+  it("copies the full origin-qualified URL and confirms", async () => {
     render(<CopyLink username="bob" />);
 
     fireEvent.click(screen.getByRole("button"));
 
     expect(writeText).toHaveBeenCalledTimes(1);
     expect(writeText).toHaveBeenCalledWith(`${window.location.origin}/to/bob`);
-    expect(toastSuccess).toHaveBeenCalledWith("Copied.");
+    // The confirmation waits on the clipboard write, so it lands a microtask
+    // later — that ordering is the point (a denied write must not "succeed").
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith("Copied."));
   });
 });

--- a/apps/web/src/components/copy-link.tsx
+++ b/apps/web/src/components/copy-link.tsx
@@ -3,11 +3,20 @@ import { Button } from "@umamin/ui/components/button";
 import { Skeleton } from "@umamin/ui/components/skeleton";
 import { Link2Icon } from "lucide-react";
 import { toast } from "sonner";
+import { captureException } from "@/lib/posthog";
 
-const onCopy = (url: string) => {
-  if (typeof window !== "undefined") {
-    navigator.clipboard.writeText(url);
+const onCopy = async (url: string) => {
+  if (typeof window === "undefined") return;
+
+  try {
+    // Awaited: an un-awaited write shows the success toast even when the
+    // clipboard write is denied.
+    await navigator.clipboard.writeText(url);
     toast.success("Copied.");
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") return;
+    captureException(err, { source: "share" });
+    toast.error("Couldn't copy the link.");
   }
 };
 
@@ -30,7 +39,7 @@ export default function CopyLink({ username }: { username: string }) {
     <Button
       type="button"
       variant="ghost"
-      onClick={() => onCopy(url)}
+      onClick={() => void onCopy(url)}
       // Inner <span> keeps the icon off the Button's direct children, so its
       // `has-[>svg]:px-3` can't override `p-0` and re-add left padding.
       className="h-auto justify-start gap-0 p-0 hover:bg-transparent text-muted-foreground flex items-center cursor-pointer"

--- a/apps/web/src/components/error-tracking.tsx
+++ b/apps/web/src/components/error-tracking.tsx
@@ -1,10 +1,28 @@
+import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
-import { initErrorTracking } from "@/lib/posthog";
+import { initErrorTracking, registerViewer } from "@/lib/posthog";
+import { queryKeys } from "@/lib/query";
+import { fetchCurrentUserOptional } from "@/lib/query-fetchers";
 
 export function ErrorTracking() {
   useEffect(() => {
     initErrorTracking();
   }, []);
+
+  // `enabled: false` so this only READS the already-resolved viewer — mounted on
+  // every page, a fetching subscription would add an /api/me round trip to every
+  // anonymous public load. The queryFn is declared purely for the result type.
+  const { data } = useQuery({
+    queryKey: queryKeys.currentUser(),
+    queryFn: fetchCurrentUserOptional,
+    enabled: false,
+  });
+
+  const viewerId = data?.user?.id;
+
+  useEffect(() => {
+    registerViewer(viewerId ?? null);
+  }, [viewerId]);
 
   return null;
 }

--- a/apps/web/src/components/follow-list-drawer.tsx
+++ b/apps/web/src/components/follow-list-drawer.tsx
@@ -46,6 +46,7 @@ import { GroupBadge } from "@/components/group-badge";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { followUserAction, unfollowUserAction } from "@/lib/actions";
 import { Link, useAppNavigate } from "@/lib/navigation";
+import { captureException } from "@/lib/posthog";
 import {
   infiniteQueryDefaults,
   PRIVATE_STALE_TIME,
@@ -342,7 +343,7 @@ function FollowUserRow({
       toast.error(
         err instanceof Error ? err.message : "Couldn't update follow.",
       );
-      console.log(err);
+      captureException(err, { source: "follow" });
     },
     onSuccess: (res, prevFollowing) => {
       // Reconcile the no-op responses (already following / already removed) so

--- a/apps/web/src/components/group-badge.tsx
+++ b/apps/web/src/components/group-badge.tsx
@@ -66,7 +66,7 @@ export function GroupBadge({
       <Link
         href={`/groups/${badge.tag}`}
         aria-label={`${badge.tag} group`}
-        prefetch={false}
+        preload={false}
       >
         {content}
       </Link>

--- a/apps/web/src/components/poll-card.tsx
+++ b/apps/web/src/components/poll-card.tsx
@@ -17,6 +17,7 @@ import {
   pollPercentages,
   pollTotalVotes,
 } from "@/lib/poll";
+import { captureException } from "@/lib/posthog";
 import { queryKeys } from "@/lib/query";
 import { patchPostAcrossFeed, patchPostResponse } from "@/lib/query-cache";
 import type {
@@ -147,7 +148,7 @@ export function PollCard({ postId, poll, isAuthenticated }: PollCardProps) {
       setMyVote(null);
       setCounts(prevCounts);
       toast.error(err instanceof Error ? err.message : "Couldn't vote.");
-      console.log(err);
+      captureException(err, { source: "poll vote" });
     }
   };
 

--- a/apps/web/src/components/post-body.tsx
+++ b/apps/web/src/components/post-body.tsx
@@ -52,7 +52,7 @@ export function PostBody({
         <Link
           key={key++}
           href={`/user/${mention}`}
-          prefetch={false}
+          preload={false}
           className="relative z-10 text-pink-500 hover:underline"
         >
           @{mention}

--- a/apps/web/src/components/profile-card-share.tsx
+++ b/apps/web/src/components/profile-card-share.tsx
@@ -17,6 +17,7 @@ import { DownloadIcon, Link2Icon, Loader2Icon, Share2Icon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { useMediaQuery } from "@/hooks/use-media-query";
+import { captureException } from "@/lib/posthog";
 import {
   type ProfileCardUser,
   renderProfileCard,
@@ -92,10 +93,20 @@ function PreviewBody({
           variant="outline"
           className="rounded-full"
           onClick={() => {
-            navigator.clipboard.writeText(
-              `${window.location.origin}/to/${username}`,
-            );
-            toast.success("Link copied — add it with a link sticker.");
+            // Awaited: an un-awaited write shows the success toast even when
+            // the clipboard write is denied.
+            void navigator.clipboard
+              .writeText(`${window.location.origin}/to/${username}`)
+              .then(() =>
+                toast.success("Link copied — add it with a link sticker."),
+              )
+              .catch((err: unknown) => {
+                if (err instanceof DOMException && err.name === "AbortError") {
+                  return;
+                }
+                captureException(err, { source: "share" });
+                toast.error("Couldn't copy the link.");
+              });
           }}
         >
           <Link2Icon />

--- a/apps/web/src/components/route-segment-error.tsx
+++ b/apps/web/src/components/route-segment-error.tsx
@@ -20,7 +20,10 @@ export function RouteSegmentError({
     console.error(error);
     // React error boundaries swallow render errors before window.onerror sees
     // them, so exception autocapture cannot pick this up on its own.
-    captureException(error, { boundary: "route-segment" });
+    captureException(error, {
+      boundary: "route-segment",
+      route: window.location.pathname,
+    });
   }, [error]);
 
   return (

--- a/apps/web/src/components/share-button.tsx
+++ b/apps/web/src/components/share-button.tsx
@@ -8,27 +8,37 @@ import {
 import { IdCardIcon, Link2Icon, Share2Icon } from "lucide-react";
 import { type ComponentProps, useState } from "react";
 import { toast } from "sonner";
+import { captureException } from "@/lib/posthog";
 import type { ProfileCardUser } from "@/lib/share-card/profile-card";
 import { ProfileCardShare } from "./profile-card-share";
 
-export function shareProfile(username: string) {
-  try {
-    if (typeof window !== "undefined") {
-      const url = `${window.location.origin}/user/${username}`;
+// A dismissed native share sheet rejects with AbortError — a user choice, not a
+// failure, so it must never mint an issue.
+function isShareAbort(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "AbortError";
+}
 
-      if (
-        navigator.share &&
-        navigator.canShare({ url }) &&
-        import.meta.env.PROD
-      ) {
-        navigator.share({ url });
-      } else {
-        navigator.clipboard.writeText(url);
-        toast.success("Profile link copied.");
-      }
+export async function shareProfile(username: string) {
+  if (typeof window === "undefined") return;
+  const url = `${window.location.origin}/user/${username}`;
+
+  try {
+    if (
+      navigator.share &&
+      navigator.canShare({ url }) &&
+      import.meta.env.PROD
+    ) {
+      await navigator.share({ url });
+    } else {
+      // Awaited: an un-awaited write shows the success toast even when the
+      // clipboard write is denied.
+      await navigator.clipboard.writeText(url);
+      toast.success("Profile link copied.");
     }
   } catch (err) {
-    console.log(err);
+    if (isShareAbort(err)) return;
+    captureException(err, { source: "share" });
+    toast.error("Couldn't share the link.");
   }
 }
 
@@ -50,7 +60,7 @@ export function ShareButton({
       // Icon inherits the button's text color (currentColor) so callers can
       // tune it via className — muted on /to, default-foreground on the banner.
       className={className}
-      onClick={() => shareProfile(username)}
+      onClick={() => void shareProfile(username)}
     >
       <Share2Icon className="size-4" />
     </Button>
@@ -68,11 +78,17 @@ export function ProfileShareMenu({
 }) {
   const [cardOpen, setCardOpen] = useState(false);
 
-  function copyProfileUrl() {
-    navigator.clipboard.writeText(
-      `${window.location.origin}/user/${user.username}`,
-    );
-    toast.success("Profile link copied.");
+  async function copyProfileUrl() {
+    try {
+      await navigator.clipboard.writeText(
+        `${window.location.origin}/user/${user.username}`,
+      );
+      toast.success("Profile link copied.");
+    } catch (err) {
+      if (isShareAbort(err)) return;
+      captureException(err, { source: "share" });
+      toast.error("Couldn't copy the link.");
+    }
   }
 
   return (
@@ -96,7 +112,7 @@ export function ProfileShareMenu({
               Share your card
             </span>
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={copyProfileUrl}>
+          <DropdownMenuItem onClick={() => void copyProfileUrl()}>
             <span className="flex items-center gap-2">
               <Link2Icon className="size-4" />
               Copy link

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,5 +1,6 @@
 import { hc } from "hono/client";
 import type { ActionsType } from "../api/actions";
+import { captureException } from "./posthog";
 
 // Typed Hono RPC client over the actions contract. Base is the ORIGIN + `/api`
 // (the actions app defines paths at `/actions/...` and is mounted under `/api`),
@@ -42,7 +43,15 @@ export async function callAction<Out>(
     });
 
     return (await res.json()) as ActionResult<Out>;
-  } catch {
+  } catch (err) {
+    // AbortError (unmount/cancel) and being offline are expected outcomes, not
+    // bugs — everything else here is a transport failure the server never saw.
+    const expected =
+      (err instanceof DOMException && err.name === "AbortError") ||
+      (typeof navigator !== "undefined" && navigator.onLine === false);
+    if (!expected) {
+      captureException(err, { source: "callAction", action: name });
+    }
     return { error: "An error occurred" };
   }
 }

--- a/apps/web/src/lib/loader-fetch.ts
+++ b/apps/web/src/lib/loader-fetch.ts
@@ -40,6 +40,7 @@
 //       the listed statuses to `emptyValue` on the server, so the SSR pass can
 //       redirect/notFound instead of crashing the loader.
 
+// Fallback when the server entry stamped no real context (the unit runner).
 // waitUntil outlives the synthetic request; swallow rejections so a background
 // cache.put failure can't crash the SSR pass.
 function stubExecutionContext(): ExecutionContext {
@@ -77,11 +78,12 @@ export function buildSsrHeaders(source: Headers): Headers {
 }
 
 async function ssrDispatch(path: string): Promise<Response> {
-  const [{ getRequest }, { apiApp }, { getSsrEnv }] = await Promise.all([
-    import("@tanstack/react-start/server"),
-    import("@/api"),
-    import("@/server-lib/ssr-env"),
-  ]);
+  const [{ getRequest }, { apiApp }, { getSsrEnv, getSsrExecutionContext }] =
+    await Promise.all([
+      import("@tanstack/react-start/server"),
+      import("@/api"),
+      import("@/server-lib/ssr-env"),
+    ]);
   const request = getRequest();
   const headers = buildSsrHeaders(request.headers);
   // apiApp is mounted at /api by the outer server — strip the prefix for the
@@ -90,11 +92,19 @@ async function ssrDispatch(path: string): Promise<Response> {
     path.replace(/^\/api(?=\/)/, ""),
     new URL(request.url).origin,
   );
-  return apiApp.fetch(
-    new Request(url, { headers }),
-    getSsrEnv(),
-    stubExecutionContext(),
-  );
+  const real = getSsrExecutionContext();
+  const exec: ExecutionContext = real
+    ? ({
+        waitUntil(promise: Promise<unknown>) {
+          // Forward so error reports / cache puts survive the SSR pass, but
+          // never let a rejection reach the page render.
+          real.waitUntil(promise.catch(() => {}));
+        },
+        passThroughOnException() {},
+        props: {},
+      } as ExecutionContext)
+    : stubExecutionContext();
+  return apiApp.fetch(new Request(url, { headers }), getSsrEnv(), exec);
 }
 
 async function fetchResponse(path: string): Promise<Response> {

--- a/apps/web/src/lib/navigation.tsx
+++ b/apps/web/src/lib/navigation.tsx
@@ -23,9 +23,6 @@ type LooseLinkProps = {
   // Per-link override of the router's defaultPreload ("intent" — hover/touch,
   // never viewport, so long feeds don't fire a request per row).
   preload?: false | "intent" | "render" | null;
-  // Swallowed: `prefetch` was next/link's prop name. Kept in the type so a
-  // ported call site that still passes it doesn't leak it onto the <a>.
-  prefetch?: unknown;
   className?: string;
   title?: string;
   target?: string;
@@ -42,12 +39,7 @@ const LooseLink = RouterLink as unknown as ComponentType<
   Record<string, unknown>
 >;
 
-export function Link({
-  to,
-  href,
-  prefetch: _prefetch,
-  ...rest
-}: LooseLinkProps) {
+export function Link({ to, href, ...rest }: LooseLinkProps) {
   return <LooseLink to={to ?? href ?? "#"} {...rest} />;
 }
 

--- a/apps/web/src/lib/posthog.ts
+++ b/apps/web/src/lib/posthog.ts
@@ -83,3 +83,18 @@ export function captureException(
   if (!ERROR_TRACKING_ENABLED || typeof window === "undefined") return;
   void load().then((posthog) => posthog?.captureException(error, properties));
 }
+
+/**
+ * Stamps the viewer's id on every subsequent client event as a super property.
+ * Deliberately `register`, never `identify` — identify would mint a billable
+ * person profile per viewer (see person_profiles above). The server reports use
+ * the same id as distinctId, so client and server issues join on it.
+ */
+export function registerViewer(userId: string | null | undefined): void {
+  if (!ERROR_TRACKING_ENABLED || typeof window === "undefined") return;
+  void load().then((posthog) => {
+    if (!posthog) return;
+    if (userId) posthog.register({ user_id: userId });
+    else posthog.unregister("user_id");
+  });
+}

--- a/apps/web/src/lib/query-cache.ts
+++ b/apps/web/src/lib/query-cache.ts
@@ -85,10 +85,9 @@ export function patchPostAcrossFeed(
     ...previous,
     pages: previous.pages.map((page) => ({
       ...page,
-      data: page.data.map((item) => ({
-        ...item,
-        post: item.post.id === postId ? updater(item.post) : item.post,
-      })),
+      data: page.data.map((item) =>
+        item.post.id === postId ? { ...item, post: updater(item.post) } : item,
+      ),
     })),
   };
 }

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -1,7 +1,14 @@
 import { formatDistanceToNow } from "date-fns";
 import { customAlphabet, nanoid } from "nanoid";
 import { toast } from "sonner";
+import { captureException } from "@/lib/posthog";
 import { hasUmaminPro } from "@/lib/pro";
+
+// A dismissed native share sheet rejects with AbortError — a user choice, not a
+// failure, so it must never mint an issue.
+function isShareAbort(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "AbortError";
+}
 
 export function generateUsernameId(length = 12) {
   const alphabet = "0123456789abcdefghijklmnopqrstuvwxyz";
@@ -115,7 +122,7 @@ async function dataUrlToPngFile(
     const blob = await (await fetch(dataUrl)).blob();
     return new File([blob], filename, { type: "image/png" });
   } catch (err) {
-    console.log(err);
+    captureException(err, { source: "save image encode" });
     return null;
   }
 }
@@ -154,7 +161,7 @@ async function padForSharing(dataUrl: string): Promise<string> {
 
     return canvas.toDataURL("image/png");
   } catch (err) {
-    console.log(err);
+    captureException(err, { source: "save image pad" });
     return dataUrl;
   }
 }
@@ -246,7 +253,9 @@ export const saveImage = async (id: string, isPost?: boolean) => {
     link.click();
     toast.success("Download ready", { id: toastId });
   } catch (err) {
-    console.log(err);
+    if (!isShareAbort(err)) {
+      captureException(err, { source: "save image" });
+    }
     toast.error("An error occured!", { id: toastId });
   } finally {
     excluded.forEach((el, i) => {
@@ -265,7 +274,11 @@ export const sharePost = (postId: string) => {
         navigator.canShare?.({ url }) &&
         import.meta.env.PROD
       ) {
-        navigator.share({ url });
+        navigator.share({ url }).catch((err) => {
+          if (!isShareAbort(err)) {
+            captureException(err, { source: "share" });
+          }
+        });
       } else {
         navigator.clipboard
           .writeText(url)
@@ -274,7 +287,7 @@ export const sharePost = (postId: string) => {
       }
     }
   } catch (err) {
-    console.log(err);
+    captureException(err, { source: "share" });
   }
 };
 

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,9 +1,11 @@
 import {
   defaultShouldDehydrateQuery,
+  MutationCache,
   QueryClient,
 } from "@tanstack/react-query";
 import { createRouter as createTanStackRouter } from "@tanstack/react-router";
 import { routerWithQueryClient } from "@tanstack/react-router-with-query";
+import { captureException } from "@/lib/posthog";
 import { routeTree } from "./routeTree.gen";
 
 export function getRouter() {
@@ -12,6 +14,21 @@ export function getRouter() {
   // ships still-pending queries so a streamed SSR load hydrates on the client.
   // (The apps/www `shouldRedactErrors:false` note was Next-specific and drops.)
   const queryClient = new QueryClient({
+    // Net for the mutationFns that actually throw. Most action call sites
+    // resolve with `{ error }` instead (covered by callAction's own capture),
+    // so this only fires for re-throwing and non-action mutations.
+    mutationCache: new MutationCache({
+      onError: (error, _variables, _context, mutation) => {
+        if (error instanceof DOMException && error.name === "AbortError")
+          return;
+        captureException(error, {
+          source: "mutation",
+          mutationKey: mutation.options.mutationKey
+            ? JSON.stringify(mutation.options.mutationKey)
+            : undefined,
+        });
+      },
+    }),
     defaultOptions: {
       queries: { staleTime: 0 },
       dehydrate: {

--- a/apps/web/src/routes/_social/-components/chat-form.tsx
+++ b/apps/web/src/routes/_social/-components/chat-form.tsx
@@ -10,6 +10,7 @@ import { ChatList } from "@/components/chat-list";
 import UnauthenticatedDialog from "@/components/unauthenticated-dialog";
 import { useDynamicTextarea } from "@/hooks/use-dynamic-textarea";
 import { useSingleFlightAction } from "@/hooks/use-single-flight-action";
+import { captureException } from "@/lib/posthog";
 import { fetchCurrentUserOptional } from "@/lib/query-fetchers";
 import type { PublicUser } from "@/lib/types";
 import { formatContent } from "@/lib/utils";
@@ -42,7 +43,7 @@ export function ChatForm({ user }: { user: PublicUser }) {
       setContent("");
     },
     onError: (err) => {
-      console.log(err);
+      captureException(err, { source: "send message" });
       toast.error(err.message ?? "Couldn't send message.");
     },
   });
@@ -58,7 +59,7 @@ export function ChatForm({ user }: { user: PublicUser }) {
 
       mutation.mutate();
     } catch (error) {
-      console.log(error);
+      captureException(error, { source: "send message session" });
       toast.error("Couldn't verify your session.");
     }
   };

--- a/apps/web/src/routes/_social/-components/current-user-note.tsx
+++ b/apps/web/src/routes/_social/-components/current-user-note.tsx
@@ -43,6 +43,7 @@ import { MusicEmbed } from "@/components/music-embed";
 import { PostBody } from "@/components/post-body";
 import { TimeAgo } from "@/components/time-ago";
 import { Link } from "@/lib/navigation";
+import { captureException } from "@/lib/posthog";
 import { pageQueryOptions, queryKeys } from "@/lib/query";
 import { patchNote } from "@/lib/query-cache";
 import { fetchCurrentNote } from "@/lib/query-fetchers";
@@ -85,7 +86,7 @@ export function CurrentUserNote({
       toast.success("Gone like it never happened.");
     },
     onError: (err) => {
-      console.log(err);
+      captureException(err, { source: "note clear" });
       toast.error(err instanceof Error ? err.message : "Couldn't clear note.");
     },
   });

--- a/apps/web/src/routes/_social/-components/note-form.tsx
+++ b/apps/web/src/routes/_social/-components/note-form.tsx
@@ -14,6 +14,7 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { SongAttachDialog } from "@/components/song-attach-dialog";
 import { MUSIC_PROVIDER_LABEL, parseMusicUrl } from "@/lib/music";
+import { captureException } from "@/lib/posthog";
 import { queryKeys } from "@/lib/query";
 import { patchNote, upsertNote } from "@/lib/query-cache";
 import type { NoteItem, NotesResponse, PublicUser } from "@/lib/types";
@@ -154,7 +155,7 @@ export function NoteForm({ currentUser }: { currentUser: PublicUser }) {
       setSongOpen(false);
     },
     onError: (err, _values, ctx) => {
-      console.log(err);
+      captureException(err, { source: "note" });
       queryClient.setQueryData<NoteItem | null>(
         queryKeys.currentNote(),
         ctx?.previousNote,

--- a/apps/web/src/routes/_social/-components/post-card-main.tsx
+++ b/apps/web/src/routes/_social/-components/post-card-main.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/hooks/use-burst-action";
 import { vibrate } from "@/lib/haptics";
 import { Link } from "@/lib/navigation";
+import { captureException } from "@/lib/posthog";
 import { queryKeys } from "@/lib/query";
 import { patchPostAcrossFeed, patchPostResponse } from "@/lib/query-cache";
 import {
@@ -173,7 +174,7 @@ export function PostCardMain({ data, imageId, isAuthenticated }: Props) {
       setLiked(prevLiked);
       setLikes(prevLikes);
       toast.error(err instanceof Error ? err.message : "Couldn't update like.");
-      console.log(err);
+      captureException(err, { source: "like" });
     }
   };
 
@@ -215,7 +216,7 @@ export function PostCardMain({ data, imageId, isAuthenticated }: Props) {
       toast.error(
         err instanceof Error ? err.message : "Couldn't update repost.",
       );
-      console.log(err);
+      captureException(err, { source: "repost" });
     }
   };
 

--- a/apps/web/src/routes/_social/-components/post-card.tsx
+++ b/apps/web/src/routes/_social/-components/post-card.tsx
@@ -31,6 +31,7 @@ import {
   useBurstAction,
 } from "@/hooks/use-burst-action";
 import { Link } from "@/lib/navigation";
+import { captureException } from "@/lib/posthog";
 import { queryKeys } from "@/lib/query";
 import {
   patchComment,
@@ -228,7 +229,7 @@ export function PostCard({
       setLiked(prevLiked);
       setLikes(prevLikes);
       toast.error(err instanceof Error ? err.message : "Couldn't update like.");
-      console.log(err);
+      captureException(err, { source: "like" });
     }
   };
 
@@ -272,7 +273,7 @@ export function PostCard({
       toast.error(
         err instanceof Error ? err.message : "Couldn't update repost.",
       );
-      console.log(err);
+      captureException(err, { source: "repost" });
     }
   };
 

--- a/apps/web/src/routes/_social/-components/post-card.tsx
+++ b/apps/web/src/routes/_social/-components/post-card.tsx
@@ -16,7 +16,7 @@ import {
   MessageSquareTextIcon,
   Repeat2Icon,
 } from "lucide-react";
-import { useEffect, useId, useState } from "react";
+import { memo, useEffect, useId, useState } from "react";
 import { toast } from "sonner";
 import { BlobatarFallback } from "@/components/blobatar-fallback";
 import { ComposeDialog } from "@/components/compose-dialog";
@@ -72,7 +72,7 @@ type Props = {
   data: PostData | CommentData;
 };
 
-export function PostCard({
+function PostCardImpl({
   data,
   isComment,
   isAuthenticated,
@@ -487,3 +487,8 @@ export function PostCard({
     </div>
   );
 }
+
+// A like/repost tap patches one post in the query cache; without this every
+// loaded card in the feed re-renders. patchPostAcrossFeed keeps unchanged items
+// reference-stable, which is what makes the default shallow compare effective.
+export const PostCard = memo(PostCardImpl);

--- a/apps/web/src/routes/_social/-components/post-list.tsx
+++ b/apps/web/src/routes/_social/-components/post-list.tsx
@@ -6,7 +6,7 @@ import {
 } from "@umamin/ui/components/alert";
 import { cn } from "@umamin/ui/lib/utils";
 import { AlertCircleIcon, MessageCircleDashedIcon } from "lucide-react";
-import { Fragment } from "react";
+import { Fragment, useMemo } from "react";
 import { ClientOnlyAdContainer } from "@/components/ad-container-client";
 import { shouldShowInFeedAd } from "@/lib/ad-placements";
 import type { FeedSort } from "@/lib/feed-sort";
@@ -59,7 +59,7 @@ export function PostList({
   const hasResolvedData = data !== undefined;
 
   // De-duplicate feed items across pages.
-  const allItems: FeedItem[] = (() => {
+  const allItems: FeedItem[] = useMemo(() => {
     const flat = data?.pages.flatMap((p) => p.data) ?? [];
     const map = new Map<string, FeedItem>();
     for (const item of flat) {
@@ -70,7 +70,7 @@ export function PostList({
       if (!map.has(key)) map.set(key, item);
     }
     return Array.from(map.values());
-  })();
+  }, [data]);
 
   const nextCursor = data?.pages[data.pages.length - 1]?.nextCursor ?? null;
 

--- a/apps/web/src/routes/_social/-components/reply-dialog.tsx
+++ b/apps/web/src/routes/_social/-components/reply-dialog.tsx
@@ -12,6 +12,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { ChatList } from "@/components/chat-list";
 import { useDynamicTextarea } from "@/hooks/use-dynamic-textarea";
+import { captureException } from "@/lib/posthog";
 import type { FeedAuthorWithBadge, NoteItem } from "@/lib/types";
 import { formatContent } from "@/lib/utils";
 import { sendMessageAction } from "../-lib/actions";
@@ -67,7 +68,7 @@ const ChatForm = ({ note }: ChatFormProps) => {
       setContent("");
     },
     onError: (err) => {
-      console.log(err);
+      captureException(err, { source: "send message" });
       toast.error(err.message ?? "Couldn't send message.");
     },
   });

--- a/apps/web/src/routes/_social/-components/user-profile.tsx
+++ b/apps/web/src/routes/_social/-components/user-profile.tsx
@@ -26,6 +26,7 @@ import { shareProfile } from "@/components/share-button";
 import { UserCard } from "@/components/user-card";
 import { YouTabs } from "@/components/you-tabs";
 import { useAppNavigate } from "@/lib/navigation";
+import { captureException } from "@/lib/posthog";
 import {
   infiniteQueryDefaults,
   PRIVATE_STALE_TIME,
@@ -117,7 +118,7 @@ export function UserProfile({ username, initialUser }: Props) {
     try {
       return await queryClient.fetchQuery(viewerQueryOptions);
     } catch (error) {
-      console.log(error);
+      captureException(error, { source: "profile viewer" });
       toast.error("Couldn't load profile actions.");
       return null;
     }
@@ -239,7 +240,7 @@ export function UserProfile({ username, initialUser }: Props) {
       toast.error(
         err instanceof Error ? err.message : "Couldn't update follow.",
       );
-      console.log(err);
+      captureException(err, { source: "follow" });
     },
     onSuccess: (res, prevFollowing, ctx) => {
       if (prevFollowing) {
@@ -348,7 +349,7 @@ export function UserProfile({ username, initialUser }: Props) {
       toast.error(
         err instanceof Error ? err.message : "Couldn't update block.",
       );
-      console.log(err);
+      captureException(err, { source: "block" });
     },
     onSuccess: (res, prevBlocked, ctx) => {
       if (prevBlocked) {
@@ -465,7 +466,7 @@ export function UserProfile({ username, initialUser }: Props) {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem onClick={() => shareProfile(profile.username)}>
+          <DropdownMenuItem onClick={() => void shareProfile(profile.username)}>
             <span className="flex items-center gap-2">
               <Share2Icon className="size-4" />
               Share

--- a/apps/web/src/routes/_social/post.$id.tsx
+++ b/apps/web/src/routes/_social/post.$id.tsx
@@ -25,27 +25,32 @@ export const Route = createFileRoute("/_social/post/$id")({
     const me = await loadViewer(context.queryClient);
     const viewerId = me?.user?.id ?? null;
 
-    const post = await loaderFetchPost(id, !!viewerId);
+    // Post and comments both branch on `viewerId` but not on each other, so
+    // they share one round trip's latency instead of chaining. Cost of the
+    // reorder: a 404'd post pays one wasted comments read.
+    const [post] = await Promise.all([
+      loaderFetchPost(id, !!viewerId),
+      context.queryClient.ensureInfiniteQueryData({
+        queryKey: queryKeys.postComments(id),
+        queryFn: ({ pageParam }) =>
+          loaderFetchPostCommentsPage(
+            id,
+            (pageParam as string | null) ?? null,
+            !!viewerId,
+          ),
+        initialPageParam: null as string | null,
+        getNextPageParam: (lastPage: CommentsResponse) =>
+          lastPage.nextCursor ?? null,
+        staleTime: PUBLIC_STALE_TIME,
+      }),
+    ]);
+
     if (!post) {
       throw notFound();
     }
 
     // Prime the per-post cache the cards patch (like/repost/comment writes).
     context.queryClient.setQueryData(queryKeys.post(id), post);
-
-    await context.queryClient.ensureInfiniteQueryData({
-      queryKey: queryKeys.postComments(id),
-      queryFn: ({ pageParam }) =>
-        loaderFetchPostCommentsPage(
-          id,
-          (pageParam as string | null) ?? null,
-          !!viewerId,
-        ),
-      initialPageParam: null as string | null,
-      getNextPageParam: (lastPage: CommentsResponse) =>
-        lastPage.nextCursor ?? null,
-      staleTime: PUBLIC_STALE_TIME,
-    });
 
     return {
       id,

--- a/apps/web/src/routes/groups.$tag.index.tsx
+++ b/apps/web/src/routes/groups.$tag.index.tsx
@@ -1,28 +1,79 @@
 import { createFileRoute, notFound } from "@tanstack/react-router";
 import { loaderFetchOptional } from "@/lib/loader-fetch";
-import { queryKeys } from "@/lib/query";
-import { fetchGroup } from "@/lib/query-fetchers";
+import { loadViewer } from "@/lib/loader-viewer";
+import { PUBLIC_STALE_TIME, queryKeys } from "@/lib/query";
+import {
+  fetchGroup,
+  fetchGroupMembersPage,
+  fetchGroupViewer,
+} from "@/lib/query-fetchers";
 import { pageSeo } from "@/lib/seo";
-import type { GroupPageData } from "@/lib/types";
+import type {
+  GroupMembersResponse,
+  GroupPageData,
+  GroupViewerResponse,
+} from "@/lib/types";
 import { GroupPageClient } from "./-groups/group-page-client";
 
 export const Route = createFileRoute("/groups/$tag/")({
   loader: async ({ context, params }) => {
-    // Seed the group query (GroupPageClient reads it as initialData) and get the
-    // meta for head(). 403/404 → null → notFound, mirroring apps/www.
-    const group = await context.queryClient.ensureQueryData({
-      queryKey: queryKeys.group(params.tag),
-      queryFn: () =>
-        loaderFetchOptional<GroupPageData | null>(
-          `/api/groups/${params.tag}`,
-          () => fetchGroup(params.tag),
-          null,
-          [403, 404],
-        ),
-    });
+    const tag = params.tag;
+
+    // Group, viewer and the membership relationship are independent, so they run
+    // together rather than as three serial round trips. Seeds the same query
+    // keys GroupPageClient reads. 403/404 → null → notFound, mirroring apps/www.
+    const [group, , viewer] = await Promise.all([
+      context.queryClient.ensureQueryData({
+        queryKey: queryKeys.group(tag),
+        queryFn: () =>
+          loaderFetchOptional<GroupPageData | null>(
+            `/api/groups/${tag}`,
+            () => fetchGroup(tag),
+            null,
+            [403, 404],
+          ),
+      }),
+      loadViewer(context.queryClient),
+      context.queryClient.ensureQueryData({
+        queryKey: queryKeys.groupViewer(tag),
+        // Must go through loaderFetchOptional, not fetchGroupViewer directly:
+        // the browser fetcher uses a relative URL, which throws in the Worker,
+        // so a hard load of this route would fail its loader on the server.
+        queryFn: () =>
+          loaderFetchOptional<GroupViewerResponse | null>(
+            `/api/groups/${tag}/viewer`,
+            () => fetchGroupViewer(tag),
+            null,
+          ),
+      }),
+    ]);
 
     if (!group) {
       throw notFound();
+    }
+
+    // The roster is the page's main content for a member, and its client query
+    // is gated on the relationship — without this prime it can only start after
+    // hydrate → viewer → members.
+    const relationship = viewer?.relationship ?? null;
+    if (relationship === "owner" || relationship === "member") {
+      await context.queryClient.ensureInfiniteQueryData({
+        queryKey: queryKeys.groupMembers(tag),
+        queryFn: ({ pageParam }) => {
+          const cursor = (pageParam as string | null) ?? null;
+          const base = `/api/groups/${tag}/members`;
+          return loaderFetchOptional<GroupMembersResponse>(
+            cursor ? `${base}?cursor=${cursor}` : base,
+            () => fetchGroupMembersPage(tag, cursor),
+            { data: [], nextCursor: null },
+            [401, 403, 404],
+          );
+        },
+        initialPageParam: null as string | null,
+        getNextPageParam: (lastPage: GroupMembersResponse) =>
+          lastPage.nextCursor ?? null,
+        staleTime: PUBLIC_STALE_TIME,
+      });
     }
 
     return { group };

--- a/apps/web/src/server-lib/context.ts
+++ b/apps/web/src/server-lib/context.ts
@@ -16,6 +16,9 @@ import { type ResolvedSession, resolveSession } from "./session";
 export type AppVariables = {
   getSession: () => Promise<ResolvedSession>;
   db?: () => Db;
+  // Set once the memoized resolver fulfills with a session, so the read
+  // wrappers' catches can attribute a report without awaiting a lookup.
+  resolvedUserId?: string;
 };
 
 export type AppBindings = { Bindings: AppEnv; Variables: AppVariables };
@@ -24,7 +27,10 @@ export function sessionContext(): MiddlewareHandler<AppBindings> {
   return async (c, next) => {
     let cached: Promise<ResolvedSession> | undefined;
     c.set("getSession", () => {
-      cached ??= resolveSession(c, getDb(c.env));
+      cached ??= resolveSession(c, getDb(c.env)).then((resolved) => {
+        if (resolved.session) c.set("resolvedUserId", resolved.session.userId);
+        return resolved;
+      });
       return cached;
     });
     await next();

--- a/apps/web/src/server-lib/cron.ts
+++ b/apps/web/src/server-lib/cron.ts
@@ -9,8 +9,10 @@ import { recomputeHotFeed as recomputeHotFeedRanking } from "./feed-rank";
 // dispatch is declarative and each job is unit-testable in isolation.
 
 // 0 3 * * * — expired sessions are otherwise pruned only lazily when their
-// owner next makes a request, so abandoned sessions accumulate forever; every
-// auth check scans this table and Turso bills per row scanned.
+// owner next makes a request, so abandoned sessions accumulate forever. A
+// session lookup is a PK seek and stays cheap; the sweep exists to bound the
+// table's size, because Turso bills per row scanned. session_expires_idx keeps
+// the sweep itself a seek rather than a full scan of what it is pruning.
 export async function cleanupSessions(env: AppEnv): Promise<void> {
   const result = await getDb(env)
     .delete(sessionTable)

--- a/apps/web/src/server-lib/data.ts
+++ b/apps/web/src/server-lib/data.ts
@@ -237,9 +237,9 @@ function withGroupBadge<U extends { equippedGroupId: string | null }>(
 
 /**
  * Resolves the quoted posts embedded in a page of posts: one bounded inArray
- * read for the quoted rows + one for their authors, and only when the page
- * actually contains quotes. A quoted id that resolves to nothing (deleted
- * post) is simply absent from the map — callers render the husk.
+ * read joined to their authors, and only when the page actually contains
+ * quotes. A quoted id that resolves to nothing (deleted post, or an author row
+ * that is gone) is simply absent from the map — callers render the husk.
  */
 async function getQuotedPostMap(
   db: Db,
@@ -256,25 +256,15 @@ async function getQuotedPostMap(
   }
 
   const quoted = await db
-    .select()
+    .select({ post: postTable, author: feedAuthorColumns })
     .from(postTable)
+    .innerJoin(userTable, eq(postTable.authorId, userTable.id))
     .where(inArray(postTable.id, ids));
-  const authorIds = Array.from(new Set(quoted.map((post) => post.authorId)));
-  const authors =
-    authorIds.length > 0
-      ? await db
-          .select(feedAuthorColumns)
-          .from(userTable)
-          .where(inArray(userTable.id, authorIds))
-      : [];
-
-  const authorMap = new Map(authors.map((author) => [author.id, author]));
 
   return new Map(
-    quoted.flatMap((post) => {
-      const author = authorMap.get(post.authorId);
-      return author ? [[post.id, { ...post, author }] as const] : [];
-    }),
+    quoted.map(
+      (row) => [row.post.id, { ...row.post, author: row.author }] as const,
+    ),
   );
 }
 
@@ -1239,24 +1229,26 @@ async function getPublicUserPostsPage(
     ? and(baseCondition, cursorCondition)
     : baseCondition;
 
-  // The author's pin surfaces above the chronological flow on the first page
-  // and is removed from its natural slot on every page (two pk lookups, only
-  // on cache miss and only when a pin exists).
-  const [pinTarget] = await db
-    .select({ pinnedPostId: userTable.pinnedPostId })
-    .from(userTable)
-    .where(eq(userTable.id, authorId))
-    .limit(1);
+  // The author's pin surfaces above the chronological flow on the first page and
+  // is removed from its natural slot on every page. The pin pointer is
+  // independent of the page window, so it rides alongside it rather than ahead
+  // of it; only the pinned ROW below has to wait on the id.
+  const [[pinTarget], rows] = await Promise.all([
+    db
+      .select({ pinnedPostId: userTable.pinnedPostId })
+      .from(userTable)
+      .where(eq(userTable.id, authorId))
+      .limit(1),
+    // Keyset pagination on post_author_created_at_idx (author_id, created_at, id).
+    db
+      .select({ post: postTable, author: feedAuthorColumns })
+      .from(postTable)
+      .innerJoin(userTable, eq(postTable.authorId, userTable.id))
+      .where(whereCondition)
+      .orderBy(desc(postTable.createdAt), desc(postTable.id))
+      .limit(FEED_PAGE_SIZE + 1),
+  ]);
   const pinnedPostId = pinTarget?.pinnedPostId ?? null;
-
-  // Keyset pagination on post_author_created_at_idx (author_id, created_at, id).
-  const rows = await db
-    .select({ post: postTable, author: feedAuthorColumns })
-    .from(postTable)
-    .innerJoin(userTable, eq(postTable.authorId, userTable.id))
-    .where(whereCondition)
-    .orderBy(desc(postTable.createdAt), desc(postTable.id))
-    .limit(FEED_PAGE_SIZE + 1);
 
   // The author guard makes a stale/corrupted pin id (e.g. of someone else's
   // post) render nothing instead of pinning foreign content.
@@ -1399,10 +1391,10 @@ async function getPostViewerOverlay(
   db: Db,
   viewerId: string,
   postId: string,
-  authorId: string,
-  // Opt-in: this overlay doubles as the quoted-post block probe, which never
-  // needs (or should pay for) a poll-vote read.
-  hasPoll = false,
+  // [0] is the post's own author; any extra ids (an embedded quote's author)
+  // are probed for blocks in the SAME round trip rather than a second overlay.
+  authorIds: string[],
+  hasPoll: boolean,
 ) {
   const [blockRows, likedRows, repostRows, voteRows] = await Promise.all([
     db
@@ -1415,10 +1407,10 @@ async function getPostViewerOverlay(
         or(
           and(
             eq(userBlockTable.blockerId, viewerId),
-            eq(userBlockTable.blockedId, authorId),
+            inArray(userBlockTable.blockedId, authorIds),
           ),
           and(
-            eq(userBlockTable.blockerId, authorId),
+            inArray(userBlockTable.blockerId, authorIds),
             eq(userBlockTable.blockedId, viewerId),
           ),
         ),
@@ -1454,8 +1446,18 @@ async function getPostViewerOverlay(
       : [],
   ]);
 
+  // Both columns matter: the viewer is the blocker on one side of the `or` and
+  // the blocked party on the other.
+  const blockedAuthorIds = new Set(
+    blockRows.map((row) =>
+      row.blockerId === viewerId ? row.blockedId : row.blockerId,
+    ),
+  );
+  const mainAuthorId = authorIds[0];
+
   return {
-    isBlocked: blockRows.length > 0,
+    isBlocked: mainAuthorId ? blockedAuthorIds.has(mainAuthorId) : false,
+    blockedAuthorIds,
     isLiked: likedRows.length > 0,
     isReposted: repostRows.length > 0,
     myVoteOptionId: voteRows[0]?.optionId ?? null,
@@ -1475,11 +1477,18 @@ export async function getPostById(
     return publicPost;
   }
 
+  // Same husk rule as the feed overlay: an embedded quote from a blocked user
+  // must not leak content its own page would hide from this viewer. The quoted
+  // author rides in the overlay's own block probe — a second overlay call would
+  // chain three more reads it never looks at.
   const overlay = await getPostViewerOverlay(
     db,
     params.viewerId,
     params.postId,
-    publicPost.author.id,
+    [
+      publicPost.author.id,
+      ...(publicPost.quotedPost ? [publicPost.quotedPost.author.id] : []),
+    ],
     !!publicPost.poll,
   );
 
@@ -1487,20 +1496,9 @@ export async function getPostById(
     return null;
   }
 
-  // Same husk rule as the feed overlay: an embedded quote from a blocked user
-  // must not leak content its own page would hide from this viewer. Reuses
-  // the cached overlay probe keyed on the quoted (post, author) pair.
   let quotedPost = publicPost.quotedPost;
-  if (quotedPost) {
-    const quotedOverlay = await getPostViewerOverlay(
-      db,
-      params.viewerId,
-      quotedPost.id,
-      quotedPost.author.id,
-    );
-    if (quotedOverlay.isBlocked) {
-      quotedPost = null;
-    }
+  if (quotedPost && overlay.blockedAuthorIds.has(quotedPost.author.id)) {
+    quotedPost = null;
   }
 
   return {
@@ -2113,18 +2111,14 @@ async function getUserProfileViewerOverlay(
   };
 }
 
-export async function getUserProfileViewerData(
+// Split out so a caller that already holds the profile row (getUserProfileData)
+// doesn't pay a second, byte-identical read for it.
+async function getUserProfileViewerDataForUser(
   db: Db,
-  username: string,
+  user: { id: string },
   viewerId?: string | null,
   opts?: { viewerIsModerator?: boolean },
-): Promise<UserProfileViewerResponse | null> {
-  const user = await getPublicUserProfileData(db, username);
-
-  if (!user) {
-    return null;
-  }
-
+): Promise<UserProfileViewerResponse> {
   if (!viewerId) {
     return {
       currentUserId: null,
@@ -2159,6 +2153,21 @@ export async function getUserProfileViewerData(
   };
 }
 
+export async function getUserProfileViewerData(
+  db: Db,
+  username: string,
+  viewerId?: string | null,
+  opts?: { viewerIsModerator?: boolean },
+): Promise<UserProfileViewerResponse | null> {
+  const user = await getPublicUserProfileData(db, username);
+
+  if (!user) {
+    return null;
+  }
+
+  return getUserProfileViewerDataForUser(db, user, viewerId, opts);
+}
+
 export async function getUserProfileData(
   db: Db,
   username: string,
@@ -2170,11 +2179,11 @@ export async function getUserProfileData(
     return user;
   }
 
-  const overlay = await getUserProfileViewerData(db, username, viewerId);
+  const overlay = await getUserProfileViewerDataForUser(db, user, viewerId);
 
   return {
     ...user,
-    ...(overlay ?? {}),
+    ...overlay,
   };
 }
 

--- a/apps/web/src/server-lib/data.ts
+++ b/apps/web/src/server-lib/data.ts
@@ -1174,10 +1174,15 @@ export async function getPostsPage(
     cursor?: string | null;
     sort?: FeedSort;
     viewerId?: string | null;
+    // Pre-fetched viewer-independent page (the caller already read it from the
+    // shared public cache entry). Never supplied for `following`, which has no
+    // viewer-independent form.
+    publicData?: FeedResponse;
   },
 ): Promise<FeedResponse> {
   const publicData =
-    params.sort === "following" && params.viewerId
+    params.publicData ??
+    (params.sort === "following" && params.viewerId
       ? await getFollowingPostsPage(db, params.viewerId, params.cursor ?? null)
       : params.sort === "latest"
         ? await getPublicLatestPostsPage(db, params.cursor ?? null)
@@ -1186,7 +1191,7 @@ export async function getPostsPage(
             kv,
             params.cursor ?? null,
             getHotFeedRankedAtMs(params.cursor ?? null),
-          );
+          ));
 
   if (!params.viewerId) {
     return publicData;
@@ -1469,9 +1474,15 @@ export async function getPostById(
   params: {
     postId: string;
     viewerId?: string | null;
+    // Pre-fetched viewer-independent post. `undefined` means "not supplied"
+    // (fetch it); a caller that already resolved a missing post shouldn't call.
+    publicPost?: PostResponse;
   },
 ): Promise<PostResponse> {
-  const publicPost = await getPublicPost(db, params.postId);
+  const publicPost =
+    params.publicPost !== undefined
+      ? params.publicPost
+      : await getPublicPost(db, params.postId);
 
   if (!publicPost || !params.viewerId) {
     return publicPost;
@@ -1646,13 +1657,13 @@ export async function getPostCommentsPage(
     postId: string;
     cursor?: string | null;
     viewerId?: string | null;
+    // Pre-fetched viewer-independent page (shared public cache entry).
+    publicData?: CommentsResponse;
   },
 ): Promise<CommentsResponse> {
-  const publicData = await getPublicCommentsPage(
-    db,
-    params.postId,
-    params.cursor ?? null,
-  );
+  const publicData =
+    params.publicData ??
+    (await getPublicCommentsPage(db, params.postId, params.cursor ?? null));
 
   if (!params.viewerId) {
     return publicData;
@@ -1841,9 +1852,12 @@ export async function getNotesPage(
   params: {
     cursor?: string | null;
     viewerId?: string | null;
+    // Pre-fetched viewer-independent page (shared public cache entry).
+    publicData?: NotesResponse;
   },
 ): Promise<NotesResponse> {
-  const publicData = await getPublicNotesPage(db, params.cursor ?? null);
+  const publicData =
+    params.publicData ?? (await getPublicNotesPage(db, params.cursor ?? null));
 
   if (!params.viewerId) {
     return publicData;

--- a/apps/web/src/server-lib/flags.ts
+++ b/apps/web/src/server-lib/flags.ts
@@ -1,5 +1,7 @@
 import { PostHog } from "posthog-node";
 import type { AppEnv } from "./env";
+import { formatErrorChain } from "./errors";
+import { captureServerException } from "./posthog";
 
 // PostHog feature flags, evaluated in the Worker.
 //
@@ -132,8 +134,13 @@ export async function resolveFlags(
   try {
     const flags = await pending;
     return { ...flags, ...pickForced(forced, keys) };
-  } catch {
+  } catch (err) {
     // Not cached: a transient failure must not pin the surface off for the TTL.
+    console.error("flag evaluation failed:", formatErrorChain(err));
+    captureServerException(env, undefined, err, {
+      distinctId,
+      properties: { flags: [...keys].sort().join(",") },
+    });
     return closed;
   }
 }

--- a/apps/web/src/server-lib/flags.ts
+++ b/apps/web/src/server-lib/flags.ts
@@ -68,18 +68,32 @@ function forcedOn(env: AppEnv): Set<string> {
   );
 }
 
+// Per-isolate, like the cache above: a client per evaluation was one more
+// object to build (and never dispose) on every cache miss.
+let flagsClient: { key: string; client: PostHog } | null = null;
+
+function getFlagsClient(env: AppEnv): PostHog {
+  const host = env.POSTHOG_HOST ?? "https://us.i.posthog.com";
+  const key = `${env.POSTHOG_PROJECT_TOKEN}:${host}`;
+  if (!flagsClient || flagsClient.key !== key) {
+    flagsClient = {
+      key,
+      client: new PostHog(env.POSTHOG_PROJECT_TOKEN as string, {
+        host,
+        flushAt: 1,
+        flushInterval: 0,
+      }),
+    };
+  }
+  return flagsClient.client;
+}
+
 async function evaluate(
   env: AppEnv,
   distinctId: string,
   keys: readonly string[],
 ): Promise<Record<string, boolean>> {
-  const client = new PostHog(env.POSTHOG_PROJECT_TOKEN as string, {
-    host: env.POSTHOG_HOST ?? "https://us.i.posthog.com",
-    flushAt: 1,
-    flushInterval: 0,
-  });
-
-  const snapshot = await client.evaluateFlags(distinctId, {
+  const snapshot = await getFlagsClient(env).evaluateFlags(distinctId, {
     flagKeys: [...keys],
   });
 
@@ -167,4 +181,5 @@ export async function isFlagEnabled(
 export function __clearFlagCache(): void {
   cache.clear();
   inflight.clear();
+  flagsClient = null;
 }

--- a/apps/web/src/server-lib/lemonsqueezy.ts
+++ b/apps/web/src/server-lib/lemonsqueezy.ts
@@ -1,4 +1,5 @@
 import type { AppEnv } from "./env";
+import { captureServerException } from "./posthog";
 
 // Server-only Lemon Squeezy transport: hosted-checkout creation + webhook
 // signature verification + the payload shapes the webhook route reads.
@@ -61,6 +62,9 @@ export async function createProCheckout(
     });
   } catch (err) {
     console.error("[pro] checkout create request failed", err);
+    captureServerException(env, undefined, err, {
+      properties: { pro: "checkout create" },
+    });
     return null;
   }
 
@@ -68,6 +72,12 @@ export async function createProCheckout(
     console.error(
       `[pro] checkout create failed: ${res.status}`,
       await res.text().catch(() => ""),
+    );
+    captureServerException(
+      env,
+      undefined,
+      new Error(`checkout create failed: ${res.status}`),
+      { properties: { pro: "checkout create" } },
     );
     return null;
   }

--- a/apps/web/src/server-lib/notification-push.ts
+++ b/apps/web/src/server-lib/notification-push.ts
@@ -6,6 +6,7 @@ import { and, eq } from "drizzle-orm";
 import { PUSH_CATEGORY } from "../lib/push-prefs";
 import type { Db } from "./db";
 import type { AppEnv } from "./env";
+import { captureServerException } from "./posthog";
 import { sendPush } from "./push";
 
 // Web Push fan-out for one in-app notification (ported from apps/www/lib/server/
@@ -212,10 +213,20 @@ export async function sendPushForNotification(
         // statusCode/retryAfterMs separate rate-limiting (429) from
         // misconfiguration (401/403 = VAPID rejected), with the endpoint — a
         // capability URL — truncated rather than logged whole.
+        // Only misconfiguration and unknown throws are reported: 429/5xx is
+        // push-service weather, not something to triage.
         if (err instanceof WebPushError) {
           console.error("web-push send rejected", err.toJSON());
+          if (err.statusCode === 401 || err.statusCode === 403) {
+            captureServerException(env, undefined, err, {
+              properties: { push: "vapid rejected", type },
+            });
+          }
         } else {
           console.error("web-push send failed", err);
+          captureServerException(env, undefined, err, {
+            properties: { push: "send failed", type },
+          });
         }
       }
     }),

--- a/apps/web/src/server-lib/notification-push.ts
+++ b/apps/web/src/server-lib/notification-push.ts
@@ -147,36 +147,42 @@ export async function sendPushForNotification(
 
   const copy = PUSH_COPY[type] ?? GENERIC_COPY;
 
-  // Preference gate (master + per-category bit; 0 = off). One bounded PK read.
-  const [recipient] = await db
-    .select({ pushPrefs: userTable.pushPrefs })
-    .from(userTable)
-    .where(eq(userTable.id, recipientId))
-    .limit(1);
-  if (!recipient || (recipient.pushPrefs & copy.category) === 0) return;
-
-  // Resolve the actor's username only for types that show one. message/reply
-  // stay anonymous: never read or reveal a sender.
-  let actor: string | null = null;
-  if (!copy.anonymous && actorId) {
-    const [row] = await db
-      .select({ username: userTable.username })
+  // All three reads key off values already in hand, so they run together rather
+  // than as three chained Tokyo round trips per engagement event. The gates
+  // below become post-filters: an opted-out recipient now pays two extra
+  // parallel reads (no extra wall-clock) so every opted-in one saves two hops.
+  const [recipientRows, actorRows, subs] = await Promise.all([
+    // Preference gate (master + per-category bit; 0 = off). One bounded PK read.
+    db
+      .select({ pushPrefs: userTable.pushPrefs })
       .from(userTable)
-      .where(eq(userTable.id, actorId))
-      .limit(1);
-    actor = row?.username ?? null;
-  }
+      .where(eq(userTable.id, recipientId))
+      .limit(1),
+    // Resolve the actor's username only for types that show one. message/reply
+    // stay anonymous: never read or reveal a sender.
+    !copy.anonymous && actorId
+      ? db
+          .select({ username: userTable.username })
+          .from(userTable)
+          .where(eq(userTable.id, actorId))
+          .limit(1)
+      : Promise.resolve([]),
+    // Bounded fan-out: a user's devices (index seek; 1-3 rows typically).
+    db
+      .select({
+        endpoint: pushSubscriptionTable.endpoint,
+        p256dh: pushSubscriptionTable.p256dh,
+        auth: pushSubscriptionTable.auth,
+      })
+      .from(pushSubscriptionTable)
+      .where(eq(pushSubscriptionTable.userId, recipientId)),
+  ]);
 
-  // Bounded fan-out: a user's devices (index seek; 1-3 rows typically).
-  const subs = await db
-    .select({
-      endpoint: pushSubscriptionTable.endpoint,
-      p256dh: pushSubscriptionTable.p256dh,
-      auth: pushSubscriptionTable.auth,
-    })
-    .from(pushSubscriptionTable)
-    .where(eq(pushSubscriptionTable.userId, recipientId));
+  const recipient = recipientRows[0];
+  if (!recipient || (recipient.pushPrefs & copy.category) === 0) return;
   if (subs.length === 0) return;
+
+  const actor = actorRows[0]?.username ?? null;
 
   const payload = {
     title: copy.title(actor),

--- a/apps/web/src/server-lib/notifications.ts
+++ b/apps/web/src/server-lib/notifications.ts
@@ -6,6 +6,7 @@ import { sql } from "drizzle-orm";
 import type { Db } from "./db";
 import type { AppEnv } from "./env";
 import { sendPushForNotification } from "./notification-push";
+import { captureServerException } from "./posthog";
 
 const PREVIEW_MAX_LENGTH = 80;
 
@@ -106,5 +107,8 @@ export async function notify(
     }
   } catch (err) {
     console.error("notify failed", err);
+    captureServerException(deps.env, deps.defer, err, {
+      properties: { notify: type, recipientId },
+    });
   }
 }

--- a/apps/web/src/server-lib/points.ts
+++ b/apps/web/src/server-lib/points.ts
@@ -1,5 +1,6 @@
+import { postTable } from "@umamin/db/schema/post";
 import { userBlockTable, userTable } from "@umamin/db/schema/user";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, ne, type SQL, sql } from "drizzle-orm";
 import type { Db } from "./db";
 
 // "Aura" point weights per engagement event — the single place to tune values.
@@ -116,4 +117,87 @@ export async function reverseAura(
     .returning({ username: userTable.username });
 
   return rows[0]?.username ?? null;
+}
+
+type PointsDb = Pick<Db, "update">;
+
+// A post's author is only knowable SQL-side when the award rides in a db.batch:
+// a batched statement cannot read a sibling's RETURNING, so the beneficiary is
+// resolved by subquery and the self-guard moves into the WHERE.
+type AuraBeneficiary = { userId: string } | { postId: string };
+
+type StatementArgs = {
+  beneficiary: AuraBeneficiary;
+  actorId: string;
+  actorCreatedAt: Date | null | undefined;
+  delta: number;
+};
+
+function beneficiaryWhere(beneficiary: AuraBeneficiary): SQL {
+  if ("userId" in beneficiary) return eq(userTable.id, beneficiary.userId);
+  return sql`${userTable.id} = (SELECT ${postTable.authorId} FROM ${postTable} WHERE ${postTable.id} = ${beneficiary.postId})`;
+}
+
+function guardsVeto({
+  beneficiary,
+  actorId,
+  actorCreatedAt,
+  delta,
+}: StatementArgs) {
+  if (delta <= 0) return true;
+  if ("userId" in beneficiary && beneficiary.userId === actorId) return true;
+  return !isAuraEligibleActor(actorCreatedAt);
+}
+
+/**
+ * Batch-composable awardAura: same guards, but returns the UPDATE statement to
+ * hand to db.batch instead of issuing it, or null when a JS-side guard already
+ * vetoes the award. `gate` is ANDed into the WHERE so the caller can tie the
+ * award to an earlier statement in the same batch having changed a row.
+ * The self-guard and the block probe correlate on the row being updated rather
+ * than a JS literal — equivalent, since the WHERE pins exactly one user row.
+ */
+export function auraAwardStatement(
+  db: PointsDb,
+  args: StatementArgs,
+  gate?: SQL,
+) {
+  if (guardsVeto(args)) return null;
+  const { beneficiary, actorId, delta } = args;
+
+  return db
+    .update(userTable)
+    .set({ points: sql`${userTable.points} + ${delta}` })
+    .where(
+      and(
+        beneficiaryWhere(beneficiary),
+        ne(userTable.id, actorId),
+        sql`NOT EXISTS (
+          SELECT 1 FROM ${userBlockTable}
+          WHERE (${userBlockTable.blockerId} = ${actorId} AND ${userBlockTable.blockedId} = ${userTable.id})
+             OR (${userBlockTable.blockerId} = ${userTable.id} AND ${userBlockTable.blockedId} = ${actorId})
+        )`,
+        gate,
+      ),
+    )
+    .returning({ username: userTable.username });
+}
+
+/** Batch-composable reverseAura — mirrors auraAwardStatement, same clamp at 0
+ *  and the same deliberate absence of a block re-check as reverseAura. */
+export function auraReverseStatement(
+  db: PointsDb,
+  args: StatementArgs,
+  gate?: SQL,
+) {
+  if (guardsVeto(args)) return null;
+  const { beneficiary, actorId, delta } = args;
+
+  return db
+    .update(userTable)
+    .set({
+      points: sql`CASE WHEN ${userTable.points} >= ${delta} THEN ${userTable.points} - ${delta} ELSE 0 END`,
+    })
+    .where(and(beneficiaryWhere(beneficiary), ne(userTable.id, actorId), gate))
+    .returning({ username: userTable.username });
 }

--- a/apps/web/src/server-lib/posthog.ts
+++ b/apps/web/src/server-lib/posthog.ts
@@ -63,7 +63,12 @@ export function captureServerException(
 
   // Without an ExecutionContext the send races the isolate shutdown; still
   // better than dropping it, and the response is never blocked either way.
-  if (waitUntil) waitUntil(sending);
+  try {
+    if (waitUntil) waitUntil(sending);
+  } catch {
+    // waitUntil can throw outside the owning request's I/O context; the send
+    // already has its own .catch, so let it race the isolate instead.
+  }
 }
 
 // Structural rather than Hono's `Context<...>`: the action layer and the read
@@ -93,13 +98,20 @@ export function captureRequestException(
     waitUntil = undefined;
   }
 
-  const url = new URL(c.req.url);
+  // `$current_url` is what PostHog's issue view reads; the query string is
+  // dropped because it carries cursors and lookup ids.
+  let currentUrl: string;
+  try {
+    const url = new URL(c.req.url);
+    currentUrl = url.origin + url.pathname;
+  } catch {
+    currentUrl = c.req.url;
+  }
+
   captureServerException(c.env, waitUntil, error, {
     ...context,
     properties: {
-      // `$current_url` is what PostHog's issue view reads; the query string is
-      // dropped because it carries cursors and lookup ids.
-      $current_url: url.origin + url.pathname,
+      $current_url: currentUrl,
       method: c.req.method,
       ...context.properties,
     },

--- a/apps/web/src/server-lib/read-route.ts
+++ b/apps/web/src/server-lib/read-route.ts
@@ -1,4 +1,5 @@
 import type { Context, HonoRequest } from "hono";
+import type { AppBindings } from "./context";
 import type { AppEnv } from "./env";
 import { formatErrorChain, INTERNAL_SERVER_ERROR } from "./errors";
 import { extractClientIp } from "./ip";
@@ -59,6 +60,13 @@ function stamp(res: Response, headers: Record<string, string>): Response {
 
 type AppContext = Context<{ Bindings: AppEnv }>;
 
+// This context is typed with bindings only (a public handler must not be able to
+// reach a session), so read the middleware-stashed viewer id through the same
+// narrow cast the read routes use for getSession.
+function viewerIdFrom(c: Context): string | undefined {
+  return (c as Context<AppBindings>).var.resolvedUserId;
+}
+
 // Private handlers get the FULL context (may resolve the viewer session).
 // `null` is a valid body (missing entity) — it still gets the private envelope.
 type PrivateReadHandler = (c: AppContext) => Promise<Response | object | null>;
@@ -89,7 +97,10 @@ export function withPrivateRead(label: string, handler: PrivateReadHandler) {
         : privateJson(result);
     } catch (error) {
       console.error(`Error ${label}:`, formatErrorChain(error));
-      captureRequestException(c, error, { properties: { read: label } });
+      captureRequestException(c, error, {
+        distinctId: viewerIdFrom(c),
+        properties: { read: label },
+      });
       return privateJson({ error: INTERNAL_SERVER_ERROR }, 500);
     }
   };
@@ -191,7 +202,10 @@ export function withPublicRead(
       return res;
     } catch (error) {
       console.error(`Error ${label}:`, formatErrorChain(error));
-      captureRequestException(c, error, { properties: { read: label } });
+      captureRequestException(c, error, {
+        distinctId: viewerIdFrom(c),
+        properties: { read: label },
+      });
       return publicJson({ error: INTERNAL_SERVER_ERROR }, 0, 0, 500);
     }
   };

--- a/apps/web/src/server-lib/read-route.ts
+++ b/apps/web/src/server-lib/read-route.ts
@@ -149,7 +149,12 @@ export function withPublicRead(
     const cache = (caches as unknown as { default: Cache }).default;
     const cacheKey = buildCacheKey(new URL(c.req.url), cacheKeyParams);
 
-    const hit = await cache.match(cacheKey);
+    let hit: Response | undefined;
+    try {
+      hit = await cache.match(cacheKey);
+    } catch {
+      // A Cache API failure must degrade to an uncached read, not a 500.
+    }
     if (hit) return hit;
 
     try {
@@ -176,7 +181,12 @@ export function withPublicRead(
         maxAgeSeconds > 0 &&
         !res.headers.has("set-cookie")
       ) {
-        c.executionCtx.waitUntil(cache.put(cacheKey, res.clone()));
+        const put = cache.put(cacheKey, res.clone()).catch(() => {});
+        try {
+          c.executionCtx.waitUntil(put);
+        } catch {
+          // No execution context (test adapter) — the put already floats safely.
+        }
       }
       return res;
     } catch (error) {

--- a/apps/web/src/server-lib/read-route.ts
+++ b/apps/web/src/server-lib/read-route.ts
@@ -139,11 +139,72 @@ function buildCacheKey(
 }
 
 /**
+ * Read-through cache for a viewer-INDEPENDENT payload, for PRIVATE handlers
+ * that overlay per-viewer state onto a shared page (feed, post, comments,
+ * notes). The key is the PAIRED PUBLIC route's canonical URL, so signed-in and
+ * anonymous traffic share one entry — and one Turso fill per TTL per colo.
+ *
+ * `maxAgeSeconds`, `browserMaxAgeSeconds` and the KEYS of `params` MUST mirror
+ * the paired `withPublicRead` declaration in api/routes/public.ts; a mismatch
+ * silently mints a second entry instead of sharing one.
+ *
+ * The two leak guards hold by construction: `produce` is a caller-built closure
+ * that must never receive anything session-derived (it feeds a SHARED entry),
+ * and `publicJson` never carries Set-Cookie. Only this payload is cached — the
+ * caller's own response keeps the private/no-store envelope from
+ * withPrivateRead, overlay included.
+ */
+export async function getCachedPublicPayload<T>(
+  c: AppContext,
+  publicPath: string,
+  params: Record<string, string | null | undefined>,
+  maxAgeSeconds: number,
+  browserMaxAgeSeconds: number,
+  produce: () => Promise<T>,
+): Promise<T> {
+  const cache = (caches as unknown as { default: Cache }).default;
+  const requestUrl = new URL(c.req.url);
+  // An SSR loader dispatches in-process with the /api mount prefix stripped
+  // (lib/loader-fetch.ts), and the public route keys off its own request URL —
+  // so mirror this request's prefix or the two never meet on one entry.
+  const prefix = requestUrl.pathname.startsWith("/api/") ? "/api" : "";
+  const url = new URL(requestUrl.origin + prefix + publicPath);
+  for (const [name, value] of Object.entries(params)) {
+    if (value) url.searchParams.set(name, value);
+  }
+  const cacheKey = buildCacheKey(url, Object.keys(params));
+
+  try {
+    const hit = await cache.match(cacheKey);
+    if (hit) return (await hit.json()) as T;
+  } catch {
+    // A Cache API failure must degrade to an uncached read, not a 500.
+  }
+
+  const payload = await produce();
+
+  // A missing entity is never stored: the public route answers that with an
+  // uncached 404, so a cached `null` body here would start answering it 200.
+  if (payload != null && maxAgeSeconds > 0) {
+    const put = cache
+      .put(cacheKey, publicJson(payload, maxAgeSeconds, browserMaxAgeSeconds))
+      .catch(() => {});
+    try {
+      c.executionCtx.waitUntil(put);
+    } catch {
+      // No execution context (test adapter) — the put already floats safely.
+    }
+  }
+
+  return payload;
+}
+
+/**
  * CDN-cached public GET scaffold. `caches.default` (per-colo) replaces Vercel's
  * s-maxage CDN cache (fact #1). Canonical key → handler → waitUntil(cache.put)
  * with s-maxage. Errors (429/500) use maxAge 0 so they're never cached.
  *
- * INVARIANTS (grep-gated to this file): `caches.default` appears ONLY here; a
+ * INVARIANTS (grep-gated): `caches.default` appears ONLY in this file; a
  * response carrying Set-Cookie is NEVER cached (would leak one viewer's cookie
  * to the next). Public handlers cannot receive a session (see PublicReadHandler).
  */
@@ -156,7 +217,7 @@ export function withPublicRead(
 ) {
   return async (c: AppContext): Promise<Response> => {
     // `caches.default` is a Workers global; the DOM lib types `caches` as a bare
-    // CacheStorage, so narrow it here (the sole `caches.default` use, R5 invariant).
+    // CacheStorage, so narrow it here (R5 invariant: this file only).
     const cache = (caches as unknown as { default: Cache }).default;
     const cacheKey = buildCacheKey(new URL(c.req.url), cacheKeyParams);
 

--- a/apps/web/src/server-lib/ssr-env.ts
+++ b/apps/web/src/server-lib/ssr-env.ts
@@ -8,8 +8,15 @@ import type { AppEnv } from "./env";
 // request in a Worker isolate shares the same env object.
 let currentEnv: AppEnv | undefined;
 
-export function setSsrEnv(env: AppEnv): void {
+// Structural for the same reason server-lib/posthog.ts is: Hono's
+// ExecutionContext is narrower than workerd's, and only waitUntil is needed.
+type SsrExecutionContext = { waitUntil: (promise: Promise<unknown>) => void };
+
+let currentCtx: SsrExecutionContext | undefined;
+
+export function setSsrEnv(env: AppEnv, ctx?: SsrExecutionContext): void {
   currentEnv = env;
+  currentCtx = ctx;
 }
 
 export function getSsrEnv(): AppEnv {
@@ -17,4 +24,10 @@ export function getSsrEnv(): AppEnv {
     throw new Error("SSR env not set — server entry must call setSsrEnv");
   }
   return currentEnv;
+}
+
+// The dispatched read's background work (error reports, cache puts) is
+// cancelled with the isolate unless it is handed to a REAL waitUntil.
+export function getSsrExecutionContext(): SsrExecutionContext | undefined {
+  return currentCtx;
 }

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -66,7 +66,12 @@ app.all("/api/*", (c) => c.json({ error: "Not found" }, 404));
 // the streamed Response body intact through the Hono wrapper. Bindings are
 // stamped for the SSR loaders' in-process API dispatch (server-lib/ssr-env.ts).
 app.all("*", (c) => {
-  setSsrEnv(c.env);
+  try {
+    setSsrEnv(c.env, c.executionCtx);
+  } catch {
+    // Hono throws on the getter when the adapter has no execution context.
+    setSsrEnv(c.env);
+  }
   return startHandler(c.req.raw);
 });
 

--- a/apps/web/test/actions-auth.test.ts
+++ b/apps/web/test/actions-auth.test.ts
@@ -14,6 +14,16 @@ vi.mock("../src/server-lib/argon2", () => ({
     phc.endsWith(Buffer.from(pw).toString("base64")),
 }));
 
+const { captureRequestException, captureServerException } = vi.hoisted(() => ({
+  captureRequestException: vi.fn(),
+  captureServerException: vi.fn(),
+}));
+
+vi.mock("../src/server-lib/posthog", () => ({
+  captureRequestException,
+  captureServerException,
+}));
+
 import { userTable } from "@umamin/db/schema/user";
 import { hash } from "../src/server-lib/argon2";
 import type { Db } from "../src/server-lib/db";
@@ -34,6 +44,7 @@ describe("auth flows (real libSQL)", () => {
 
   beforeEach(async () => {
     __clearSessionCache();
+    captureRequestException.mockClear();
     db = await makeTestDb();
   });
 
@@ -142,5 +153,32 @@ describe("auth flows (real libSQL)", () => {
       confirmPassword: "password123",
     });
     expect(json).toEqual({ error: "Username already exists" });
+    // A taken username is an expected outcome, not something to triage.
+    expect(captureRequestException).not.toHaveBeenCalled();
+  });
+
+  // Signup is mounted outside action(), so its catch is the only chokepoint an
+  // unmapped failure (a Turso outage mid-signup) can reach.
+  it("reports an unmapped signup failure while keeping the generic error", async () => {
+    const failing = new Proxy(db, {
+      get(target, prop, receiver) {
+        if (prop === "insert") {
+          return () => {
+            throw new Error("turso unreachable");
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    }) as Db;
+
+    const { json } = await callJson(buildApp(failing, ANON), "signup", {
+      username: "carol1",
+      password: "password123",
+      confirmPassword: "password123",
+    });
+
+    expect(json).toEqual({ error: "An unexpected error occurred" });
+    expect(captureRequestException).toHaveBeenCalledTimes(1);
+    expect(captureRequestException.mock.calls[0][1]).toBeInstanceOf(Error);
   });
 });

--- a/apps/web/test/actions-post.test.ts
+++ b/apps/web/test/actions-post.test.ts
@@ -8,7 +8,7 @@ vi.mock("../src/server-lib/argon2", () => ({
 }));
 
 import { postLikeTable, postTable } from "@umamin/db/schema/post";
-import { userTable } from "@umamin/db/schema/user";
+import { userBlockTable, userTable } from "@umamin/db/schema/user";
 import { eq } from "drizzle-orm";
 import type { Db } from "../src/server-lib/db";
 import { __clearSessionCache } from "../src/server-lib/session";
@@ -71,6 +71,50 @@ describe("post actions (real libSQL)", () => {
     expect(await points(db, "author")).toBe(2);
   });
 
+  it("a self-like counts but awards the author no aura", async () => {
+    const app = buildApp(db, authed("author", { createdAt: OLD }));
+    const { json } = await callJson(app, "addLikeAction", { postId: "p1" });
+
+    expect(json).toEqual({ success: true });
+    const [post] = await db
+      .select({ likeCount: postTable.likeCount })
+      .from(postTable)
+      .where(eq(postTable.id, "p1"));
+    expect(post.likeCount).toBe(1);
+    expect(await points(db, "author")).toBe(0);
+  });
+
+  // The batched award resolves the author by subquery, so the block probe
+  // correlates on the row being updated rather than a JS-side literal.
+  it("a like from a blocked user counts but awards no aura", async () => {
+    await db
+      .insert(userBlockTable)
+      .values({ blockerId: "author", blockedId: "viewer" });
+    const app = buildApp(db, authed("viewer", { createdAt: OLD }));
+    const { json } = await callJson(app, "addLikeAction", { postId: "p1" });
+
+    expect(json).toEqual({ success: true });
+    const [post] = await db
+      .select({ likeCount: postTable.likeCount })
+      .from(postTable)
+      .where(eq(postTable.id, "p1"));
+    expect(post.likeCount).toBe(1);
+    expect(await points(db, "author")).toBe(0);
+  });
+
+  it("a like from an under-age actor counts but awards no aura", async () => {
+    const app = buildApp(db, authed("viewer", { createdAt: new Date() }));
+    const { json } = await callJson(app, "addLikeAction", { postId: "p1" });
+
+    expect(json).toEqual({ success: true });
+    const [post] = await db
+      .select({ likeCount: postTable.likeCount })
+      .from(postTable)
+      .where(eq(postTable.id, "p1"));
+    expect(post.likeCount).toBe(1);
+    expect(await points(db, "author")).toBe(0);
+  });
+
   it("removeLikeAction reverses the like and the aura", async () => {
     const app = buildApp(db, authed("viewer", { createdAt: OLD }));
     await callJson(app, "addLikeAction", { postId: "p1" });
@@ -83,6 +127,22 @@ describe("post actions (real libSQL)", () => {
       .where(eq(postLikeTable.postId, "p1"));
     expect(rows).toHaveLength(0);
     expect(await points(db, "author")).toBe(0);
+  });
+
+  it("unliking a post the viewer never liked leaves the count alone", async () => {
+    await db
+      .update(postTable)
+      .set({ likeCount: 3 })
+      .where(eq(postTable.id, "p1"));
+    const app = buildApp(db, authed("viewer", { createdAt: OLD }));
+    const { json } = await callJson(app, "removeLikeAction", { postId: "p1" });
+
+    expect(json).toEqual({ success: true, alreadyRemoved: true });
+    const [post] = await db
+      .select({ likeCount: postTable.likeCount })
+      .from(postTable)
+      .where(eq(postTable.id, "p1"));
+    expect(post.likeCount).toBe(3);
   });
 
   it("createCommentAction bumps commentCount and awards first-comment aura", async () => {

--- a/apps/web/test/batch-changes.test.ts
+++ b/apps/web/test/batch-changes.test.ts
@@ -1,0 +1,146 @@
+import { postLikeTable, postTable } from "@umamin/db/schema/post";
+import { userTable } from "@umamin/db/schema/user";
+import { and, eq, sql } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Db } from "../src/server-lib/db";
+import { makeTestDb } from "./helpers/db";
+
+// Characterization of SQLite's changes() ACROSS the statements of one
+// db.batch, which is what lets the like/unlike handlers replace an interactive
+// transaction (one HTTP round trip per await) with a single batched round trip:
+// the JS-side `if (inserted.length === 0) return` branch becomes an SQL gate.
+// A batch runs sequentially on ONE connection (local file client here, one
+// Hrana stream in production), so changes() reads the previous statement's
+// row count. Keep this suite as the guard for @libsql/client upgrades.
+
+const GATE = sql`(SELECT changes()) > 0`;
+
+async function seed(db: Db) {
+  await db.insert(userTable).values([
+    { id: "author", username: "u_author" },
+    { id: "viewer", username: "u_viewer" },
+  ]);
+  await db
+    .insert(postTable)
+    .values({ id: "p1", content: "hello", authorId: "author" });
+}
+
+function likeInsert(db: Db, userId: string) {
+  return db
+    .insert(postLikeTable)
+    .values({ postId: "p1", userId })
+    .onConflictDoNothing()
+    .returning({ id: postLikeTable.id });
+}
+
+function gatedBump(db: Db, postId = "p1") {
+  return db
+    .update(postTable)
+    .set({ likeCount: sql`${postTable.likeCount} + 1` })
+    .where(and(eq(postTable.id, postId), GATE))
+    .returning({ authorId: postTable.authorId });
+}
+
+function gatedAward(db: Db) {
+  return db
+    .update(userTable)
+    .set({ points: sql`${userTable.points} + 2` })
+    .where(and(eq(userTable.id, "author"), GATE))
+    .returning({ username: userTable.username });
+}
+
+async function counts(db: Db) {
+  const [post] = await db
+    .select({ likeCount: postTable.likeCount })
+    .from(postTable)
+    .where(eq(postTable.id, "p1"));
+  const [author] = await db
+    .select({ points: userTable.points })
+    .from(userTable)
+    .where(eq(userTable.id, "author"));
+  return { likeCount: post.likeCount, points: author.points };
+}
+
+describe("changes() gating inside one db.batch", () => {
+  let db: Db;
+
+  beforeEach(async () => {
+    db = await makeTestDb();
+    await seed(db);
+  });
+
+  it("opens the gate for every downstream statement when the insert inserted", async () => {
+    const [inserted, bumped, awarded] = await db.batch([
+      likeInsert(db, "viewer"),
+      gatedBump(db),
+      gatedAward(db),
+    ]);
+
+    expect(inserted).toHaveLength(1);
+    expect(bumped).toEqual([{ authorId: "author" }]);
+    expect(awarded).toEqual([{ username: "u_author" }]);
+    expect(await counts(db)).toEqual({ likeCount: 1, points: 2 });
+  });
+
+  it("closes the gate for every downstream statement when the insert conflicted", async () => {
+    await db.batch([likeInsert(db, "viewer"), gatedBump(db), gatedAward(db)]);
+
+    const [inserted, bumped, awarded] = await db.batch([
+      likeInsert(db, "viewer"),
+      gatedBump(db),
+      gatedAward(db),
+    ]);
+
+    expect(inserted).toEqual([]);
+    expect(bumped).toEqual([]);
+    expect(awarded).toEqual([]);
+    expect(await counts(db)).toEqual({ likeCount: 1, points: 2 });
+  });
+
+  // The chain only transitively encodes the insert because a statement that
+  // matched NO rows reports changes() = 0 rather than leaving the previous
+  // statement's count standing. Without this, a skipped bump would let the
+  // award through on the insert's own count.
+  it("an update that matched no rows closes the gate for the next statement", async () => {
+    const [inserted, missed, awarded] = await db.batch([
+      likeInsert(db, "viewer"),
+      db
+        .update(postTable)
+        .set({ likeCount: sql`${postTable.likeCount} + 1` })
+        .where(eq(postTable.id, "does-not-exist"))
+        .returning({ authorId: postTable.authorId }),
+      gatedAward(db),
+    ]);
+
+    expect(inserted).toHaveLength(1);
+    expect(missed).toEqual([]);
+    expect(awarded).toEqual([]);
+    expect(await counts(db)).toEqual({ likeCount: 0, points: 0 });
+  });
+
+  it("delete-driven gating mirrors insert-driven gating", async () => {
+    await db
+      .insert(postLikeTable)
+      .values({ postId: "p1", userId: "viewer" })
+      .onConflictDoNothing();
+
+    const removal = () =>
+      db
+        .delete(postLikeTable)
+        .where(
+          and(
+            eq(postLikeTable.postId, "p1"),
+            eq(postLikeTable.userId, "viewer"),
+          ),
+        )
+        .returning({ id: postLikeTable.id });
+
+    const [removed, bumped] = await db.batch([removal(), gatedBump(db)]);
+    expect(removed).toHaveLength(1);
+    expect(bumped).toEqual([{ authorId: "author" }]);
+
+    const [reRemoved, notBumped] = await db.batch([removal(), gatedBump(db)]);
+    expect(reRemoved).toEqual([]);
+    expect(notBumped).toEqual([]);
+  });
+});

--- a/apps/web/test/cached-public-payload.worker.test.ts
+++ b/apps/web/test/cached-public-payload.worker.test.ts
@@ -1,0 +1,223 @@
+import {
+  createExecutionContext,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import type { AppEnv } from "../src/server-lib/env";
+import {
+  getCachedPublicPayload,
+  withPrivateRead,
+} from "../src/server-lib/read-route";
+
+// caches.default is real in the workers pool. env is minimal ({}) → the read
+// rate limiter fails open (missing binding), which is fine here.
+//
+// These pin the guards that make a PRIVATE handler safe to serve off the PUBLIC
+// route's shared cache entry: the producer runs once per key, the viewer
+// overlay never reaches the entry, and a missing entity is never stored (a
+// cached `null` would turn the public route's 404 into a 200).
+const ENV = {} as AppEnv;
+
+let produced = 0;
+
+const cacheStore = (caches as unknown as { default: Cache }).default;
+
+function cachedAt(pathname: string, search = "") {
+  return cacheStore.match(
+    new Request(`https://x.test${pathname}${search}`, { method: "GET" }),
+  );
+}
+
+const app = new Hono<{ Bindings: AppEnv }>()
+  .get(
+    "/feed",
+    withPrivateRead("feed", async (c) => {
+      const key = c.req.query("key") ?? "";
+      const cursor = c.req.query("cursor") ?? null;
+      const payload = await getCachedPublicPayload<{ n: number; key: string }>(
+        c,
+        "/public/feed",
+        { key, cursor },
+        180,
+        60,
+        async () => {
+          produced += 1;
+          return { n: produced, key };
+        },
+      );
+      // Stand-in for the per-viewer overlay a real private handler applies.
+      return { ...payload, viewer: "me" };
+    }),
+  )
+  .get(
+    "/missing",
+    withPrivateRead("missing", async (c) => {
+      const key = c.req.query("key") ?? "";
+      const payload = await getCachedPublicPayload<{ n: number } | null>(
+        c,
+        "/public/missing",
+        { key },
+        180,
+        60,
+        async () => {
+          produced += 1;
+          return null;
+        },
+      );
+      return { payload };
+    }),
+  );
+
+// Same routes reachable under the /api mount prefix, which is what a real
+// network request carries and what an in-process SSR loader dispatch strips.
+const apiApp = new Hono().route("/api", app);
+
+async function fetchPrivate(path: string, mounted = app as unknown as Hono) {
+  const ctx = createExecutionContext();
+  const res = await mounted.fetch(
+    new Request(`https://x.test${path}`),
+    ENV,
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+describe("getCachedPublicPayload (workers Cache API)", () => {
+  it("shares one entry: the producer runs once per key", async () => {
+    const key = crypto.randomUUID();
+    const first = await (await fetchPrivate(`/feed?key=${key}`)).json<{
+      n: number;
+    }>();
+    const before = produced;
+    const second = await (await fetchPrivate(`/feed?key=${key}`)).json<{
+      n: number;
+    }>();
+
+    expect(second.n).toBe(first.n);
+    expect(produced).toBe(before); // second read never reached the producer
+  });
+
+  it("caches the PUBLIC payload only — the viewer overlay never enters the entry", async () => {
+    const key = crypto.randomUUID();
+    const res = await fetchPrivate(`/feed?key=${key}`);
+
+    // The response the viewer gets carries the overlay and the private envelope.
+    expect(await res.json()).toEqual({
+      n: expect.any(Number),
+      key,
+      viewer: "me",
+    });
+    expect(res.headers.get("cache-control")).toBe(
+      "private, no-store, max-age=0",
+    );
+    expect(res.headers.get("vary")).toBe("Cookie");
+
+    const cached = await cachedAt("/public/feed", `?key=${key}`);
+    expect(cached).toBeDefined();
+    const body = await cached?.json<Record<string, unknown>>();
+    expect(body).not.toHaveProperty("viewer");
+    expect(body).toEqual({ n: expect.any(Number), key });
+    expect(cached?.headers.get("cache-control")).toBe(
+      "public, max-age=60, s-maxage=180, stale-while-revalidate=180",
+    );
+    expect(cached?.headers.has("set-cookie")).toBe(false);
+  });
+
+  it("canonicalizes the key: a null/empty declared param and undeclared params collapse onto one entry", async () => {
+    const key = crypto.randomUUID();
+    const first = await (await fetchPrivate(`/feed?key=${key}`)).json<{
+      n: number;
+    }>();
+    const before = produced;
+
+    // cursor present but empty → dropped from the key, same entry.
+    const withEmptyCursor = await (
+      await fetchPrivate(`/feed?key=${key}&cursor=`)
+    ).json<{ n: number }>();
+    // an undeclared param must not mint a fresh entry (and a fresh Turso read).
+    const withJunk = await (
+      await fetchPrivate(`/feed?key=${key}&utm_source=x`)
+    ).json<{ n: number }>();
+
+    expect(withEmptyCursor.n).toBe(first.n);
+    expect(withJunk.n).toBe(first.n);
+    expect(produced).toBe(before);
+  });
+
+  it("separates distinct declared values", async () => {
+    const key = crypto.randomUUID();
+    const a = await (await fetchPrivate(`/feed?key=${key}`)).json<{
+      n: number;
+    }>();
+    const b = await (await fetchPrivate(`/feed?key=${key}&cursor=page2`)).json<{
+      n: number;
+    }>();
+
+    expect(b.n).toBeGreaterThan(a.n);
+    expect(
+      await cachedAt("/public/feed", `?cursor=page2&key=${key}`),
+    ).toBeDefined();
+  });
+
+  it("mirrors the caller's /api mount prefix so both dispatch modes key alike", async () => {
+    const key = crypto.randomUUID();
+    await fetchPrivate(`/api/feed?key=${key}`, apiApp);
+
+    expect(await cachedAt("/api/public/feed", `?key=${key}`)).toBeDefined();
+    // The prefix-less form is a DIFFERENT entry — it must not have been filled.
+    expect(await cachedAt("/public/feed", `?key=${key}`)).toBeUndefined();
+  });
+
+  // A cached `null` under the public key would answer the public route's 404
+  // with a 200 body of `null`.
+  it("never stores a null payload (the public route's 404 stays uncached)", async () => {
+    const key = crypto.randomUUID();
+    const before = produced;
+    expect(await (await fetchPrivate(`/missing?key=${key}`)).json()).toEqual({
+      payload: null,
+    });
+
+    expect(await cachedAt("/public/missing", `?key=${key}`)).toBeUndefined();
+
+    await fetchPrivate(`/missing?key=${key}`);
+    expect(produced).toBe(before + 2); // recomputed — nothing was stored
+  });
+
+  it("degrades to an uncached read when the Cache API throws", async () => {
+    const real = (globalThis as { caches: unknown }).caches;
+    let installed = false;
+    try {
+      Object.defineProperty(globalThis, "caches", {
+        configurable: true,
+        value: {
+          default: {
+            match: () => Promise.reject(new Error("cache down")),
+            put: () => Promise.reject(new Error("cache down")),
+          },
+        },
+      });
+      installed = true;
+    } catch {
+      // Not stubbable in this pool — the guard would go uncovered.
+    }
+    expect(installed).toBe(true);
+
+    try {
+      const key = crypto.randomUUID();
+      const res = await fetchPrivate(`/feed?key=${key}`);
+      expect(res.status).toBe(200); // a Cache API failure is not a 500
+      expect(await res.json()).toEqual({
+        n: expect.any(Number),
+        key,
+        viewer: "me",
+      });
+    } finally {
+      Object.defineProperty(globalThis, "caches", {
+        configurable: true,
+        value: real,
+      });
+    }
+  });
+});

--- a/apps/web/test/client-capture.test.ts
+++ b/apps/web/test/client-capture.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const captureException = vi.fn();
+vi.mock("@/lib/posthog", () => ({
+  ERROR_TRACKING_ENABLED: false,
+  initErrorTracking: vi.fn(),
+  registerViewer: vi.fn(),
+  captureException: (error: unknown, properties?: Record<string, unknown>) =>
+    captureException(error, properties),
+}));
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    success: (m: string) => toastSuccess(m),
+    error: (m: string) => toastError(m),
+  },
+}));
+
+const { callAction } = await import("@/lib/api");
+const { shareProfile } = await import("@/components/share-button");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// callAction normalizes every transport failure into `{ error }` so call sites
+// never have to try/catch. That is also how a broken deploy, a CSP block or a
+// credentials bug used to vanish: the server never saw the request, so PostHog
+// is the only place the failure can surface.
+describe("callAction transport failures", () => {
+  it("reports a failed request the server never received", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new TypeError("Failed to fetch")),
+    );
+
+    const res = await callAction("likePostAction");
+
+    expect(res).toEqual({ error: "An error occurred" });
+    expect(captureException).toHaveBeenCalledWith(
+      expect.any(TypeError),
+      expect.objectContaining({
+        source: "callAction",
+        action: "likePostAction",
+      }),
+    );
+  });
+
+  it("stays silent when the caller aborted the request", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new DOMException("aborted", "AbortError")),
+    );
+
+    const res = await callAction("likePostAction");
+
+    expect(res).toEqual({ error: "An error occurred" });
+    expect(captureException).not.toHaveBeenCalled();
+  });
+});
+
+// jsdom leaves navigator.share undefined, so shareProfile takes the clipboard
+// branch. The regression: the write used to be un-awaited, so a denied
+// clipboard still showed "Profile link copied."
+describe("shareProfile clipboard failures", () => {
+  it("does not claim success when the clipboard write is rejected", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+      configurable: true,
+    });
+
+    await shareProfile("alice");
+
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/test/data-post.test.ts
+++ b/apps/web/test/data-post.test.ts
@@ -1,0 +1,54 @@
+import { postTable } from "@umamin/db/schema/post";
+import { userBlockTable, userTable } from "@umamin/db/schema/user";
+import { beforeEach, describe, expect, it } from "vitest";
+import { getPostById } from "../src/server-lib/data";
+import type { Db } from "../src/server-lib/db";
+import { makeTestDb } from "./helpers/db";
+
+// One block probe now covers the post's author AND its embedded quote's author,
+// so the two must stay independently enforced: blocking the quote hides only the
+// quote, blocking the author hides the whole post.
+describe("getPostById block husks (real libSQL)", () => {
+  let db: Db;
+
+  beforeEach(async () => {
+    db = await makeTestDb();
+    await db.insert(userTable).values([
+      { id: "author", username: "u_author" },
+      { id: "quoted", username: "u_quoted" },
+      { id: "viewer", username: "u_viewer" },
+    ]);
+    await db.insert(postTable).values([
+      { id: "q1", content: "quoted", authorId: "quoted" },
+      { id: "p1", content: "quoting", authorId: "author", quotedPostId: "q1" },
+    ]);
+  });
+
+  it("returns the post with the quote nulled when only the quoted author is blocked", async () => {
+    await db
+      .insert(userBlockTable)
+      .values({ id: "b1", blockerId: "quoted", blockedId: "viewer" });
+
+    const post = await getPostById(db, { postId: "p1", viewerId: "viewer" });
+
+    expect(post?.id).toBe("p1");
+    expect(post?.quotedPost).toBeNull();
+  });
+
+  it("hides the whole post when the post's own author is blocked", async () => {
+    await db
+      .insert(userBlockTable)
+      .values({ id: "b1", blockerId: "viewer", blockedId: "author" });
+
+    expect(
+      await getPostById(db, { postId: "p1", viewerId: "viewer" }),
+    ).toBeNull();
+  });
+
+  it("keeps the quote when neither author is blocked", async () => {
+    const post = await getPostById(db, { postId: "p1", viewerId: "viewer" });
+
+    expect(post?.quotedPost?.id).toBe("q1");
+    expect(post?.quotedPost?.author.username).toBe("u_quoted");
+  });
+});

--- a/apps/web/test/flags.test.ts
+++ b/apps/web/test/flags.test.ts
@@ -12,6 +12,12 @@ vi.mock("posthog-node", () => ({
   },
 }));
 
+const captureServerException = vi.fn();
+vi.mock("@/server-lib/posthog", () => ({
+  captureServerException,
+  captureRequestException: vi.fn(),
+}));
+
 const { FLAG_UMAMIN_PRO } = await import("@/lib/flags");
 const { __clearFlagCache, isFlagEnabled, resolveFlags } = await import(
   "@/server-lib/flags"
@@ -33,6 +39,7 @@ beforeEach(() => {
   __clearFlagCache();
   evaluateFlags.mockReset();
   construct.mockReset();
+  captureServerException.mockReset();
   evaluateFlags.mockResolvedValue(snapshot({ [FLAG_UMAMIN_PRO]: true }));
 });
 
@@ -64,6 +71,18 @@ describe("resolveFlags", () => {
     evaluateFlags.mockRejectedValue(new Error("flags down"));
     const flags = await resolveFlags(ENV, "user_1", [FLAG_UMAMIN_PRO]);
     expect(flags[FLAG_UMAMIN_PRO]).toBe(false);
+  });
+
+  // Failing closed hides a launched surface, and Workers Logs alone would never
+  // show it — the report is the only signal that it happened.
+  it("reports the evaluation failure against the viewer", async () => {
+    evaluateFlags.mockRejectedValue(new Error("flags down"));
+    await resolveFlags(ENV, "user_1", [FLAG_UMAMIN_PRO]);
+    expect(captureServerException).toHaveBeenCalledTimes(1);
+    expect(captureServerException.mock.calls[0][3]).toEqual({
+      distinctId: "user_1",
+      properties: { flags: FLAG_UMAMIN_PRO },
+    });
   });
 
   it("resolves false without a project token, and never calls out", async () => {

--- a/apps/web/test/posthog-client.test.ts
+++ b/apps/web/test/posthog-client.test.ts
@@ -8,11 +8,22 @@ let sdkImports = 0;
 
 vi.mock("posthog-js", () => {
   sdkImports++;
-  return { default: { init, register: vi.fn(), captureException: vi.fn() } };
+  return {
+    default: {
+      init,
+      register: vi.fn(),
+      unregister: vi.fn(),
+      captureException: vi.fn(),
+    },
+  };
 });
 
-const { ERROR_TRACKING_ENABLED, captureException, initErrorTracking } =
-  await import("@/lib/posthog");
+const {
+  ERROR_TRACKING_ENABLED,
+  captureException,
+  initErrorTracking,
+  registerViewer,
+} = await import("@/lib/posthog");
 
 // Vitest runs with `import.meta.env.PROD === false`, the same shape as
 // `pnpm dev:web`. The point of these is that a non-PROD build never loads
@@ -22,9 +33,13 @@ describe("browser error tracking, unconfigured", () => {
     expect(ERROR_TRACKING_ENABLED).toBe(false);
   });
 
+  // Every public entry point is exercised: each one is a place a missing
+  // ERROR_TRACKING_ENABLED guard would pull the SDK in.
   it("never imports or initializes the SDK", async () => {
     initErrorTracking();
     captureException(new Error("boom"));
+    registerViewer("user_123");
+    registerViewer(null);
     // A macrotask, so a dynamic import would have settled by the assertion.
     await new Promise((resolve) => setTimeout(resolve, 0));
 

--- a/apps/web/test/posthog.test.ts
+++ b/apps/web/test/posthog.test.ts
@@ -139,6 +139,18 @@ describe("captureServerException", () => {
     ).not.toThrow();
     expect(captureExceptionImmediate).toHaveBeenCalledTimes(1);
   });
+
+  // workerd rejects waitUntil once the owning request's I/O context is gone; a
+  // throw here would re-enter app.onError and report again.
+  it("does not throw when waitUntil itself throws", () => {
+    const waitUntil = vi.fn(() => {
+      throw new Error("no I/O context");
+    });
+    expect(() =>
+      captureServerException(PROD_ENV, waitUntil, new Error("boom")),
+    ).not.toThrow();
+    expect(captureExceptionImmediate).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("captureRequestException", () => {
@@ -169,6 +181,19 @@ describe("captureRequestException", () => {
     } as any;
     expect(() => captureRequestException(c, new Error("boom"))).not.toThrow();
     expect(captureExceptionImmediate).toHaveBeenCalledTimes(1);
+  });
+
+  // The URL comes off the request, so a malformed one must degrade the property
+  // rather than take down the reporter its caller's catch depends on.
+  it("does not throw on an unparseable request URL", () => {
+    const c = requestContext(PROD_ENV);
+    c.req.url = "not a url";
+    expect(() => captureRequestException(c, new Error("boom"))).not.toThrow();
+    expect(captureExceptionImmediate).toHaveBeenCalledWith(
+      expect.any(Error),
+      undefined,
+      expect.objectContaining({ $current_url: "not a url" }),
+    );
   });
 
   it("stays silent for an unconfigured environment", () => {

--- a/apps/web/test/query-cache.test.ts
+++ b/apps/web/test/query-cache.test.ts
@@ -1,0 +1,40 @@
+import type { InfiniteData } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+import { patchPostAcrossFeed } from "@/lib/query-cache";
+import type { FeedItem, FeedResponse, PostData } from "@/lib/types";
+
+function makeItem(id: string): FeedItem {
+  return {
+    type: "post",
+    post: { id, likeCount: 0, isLiked: false } as unknown as PostData,
+  };
+}
+
+function makeFeed(ids: string[]): InfiniteData<FeedResponse> {
+  return {
+    pageParams: [null],
+    pages: [{ data: ids.map(makeItem), nextCursor: null }],
+  };
+}
+
+describe("patchPostAcrossFeed", () => {
+  it("applies the update to the matching post", () => {
+    const previous = makeFeed(["a", "b"]);
+    const next = patchPostAcrossFeed(previous, "a", (post) => ({
+      ...post,
+      likeCount: 1,
+    }));
+    expect(next?.pages[0]?.data[0]?.post.likeCount).toBe(1);
+  });
+
+  // Identity is the point: PostCard is memoized, so a like tap must not hand
+  // every other card a fresh item wrapper and re-render the whole feed.
+  it("returns the same item reference for a non-matching post", () => {
+    const previous = makeFeed(["a", "b"]);
+    const next = patchPostAcrossFeed(previous, "a", (post) => ({
+      ...post,
+      likeCount: 1,
+    }));
+    expect(next?.pages[0]?.data[1]).toBe(previous.pages[0]?.data[1]);
+  });
+});

--- a/packages/db/migrations/0025_noisy_night_thrasher.sql
+++ b/packages/db/migrations/0025_noisy_night_thrasher.sql
@@ -1,0 +1,2 @@
+CREATE INDEX `notification_updated_idx` ON `notification` (`updated_at`);--> statement-breakpoint
+CREATE INDEX `session_expires_idx` ON `session` (`expires_at`);

--- a/packages/db/migrations/meta/0025_snapshot.json
+++ b/packages/db/migrations/meta/0025_snapshot.json
@@ -1,0 +1,2305 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "410c7433-2152-4aa8-bd2c-d7cf45e3db35",
+  "prevId": "4da2792f-6acf-4674-8be7-514be268353f",
+  "tables": {
+    "group_message_reaction": {
+      "name": "group_message_reaction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "group_message_reaction_message_user_uidx": {
+          "name": "group_message_reaction_message_user_uidx",
+          "columns": ["message_id", "user_id"],
+          "isUnique": true
+        },
+        "group_message_reaction_user_message_idx": {
+          "name": "group_message_reaction_user_message_idx",
+          "columns": ["user_id", "message_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "group_message_reaction_message_id_group_message_id_fk": {
+          "name": "group_message_reaction_message_id_group_message_id_fk",
+          "tableFrom": "group_message_reaction",
+          "tableTo": "group_message",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_message_reaction_user_id_user_id_fk": {
+          "name": "group_message_reaction_user_id_user_id_fk",
+          "tableFrom": "group_message_reaction",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group_message_read": {
+      "name": "group_message_read",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_read_message_id": {
+          "name": "last_read_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "group_message_read_group_user_uidx": {
+          "name": "group_message_read_group_user_uidx",
+          "columns": ["group_id", "user_id"],
+          "isUnique": true
+        },
+        "group_message_read_user_idx": {
+          "name": "group_message_read_user_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "group_message_read_group_id_group_id_fk": {
+          "name": "group_message_read_group_id_group_id_fk",
+          "tableFrom": "group_message_read",
+          "tableTo": "group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_message_read_user_id_user_id_fk": {
+          "name": "group_message_read_user_id_user_id_fk",
+          "tableFrom": "group_message_read",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group_message": {
+      "name": "group_message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reply_to_message_id": {
+          "name": "reply_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "group_message_group_created_id_idx": {
+          "name": "group_message_group_created_id_idx",
+          "columns": ["group_id", "created_at", "id"],
+          "isUnique": false
+        },
+        "group_message_sender_idx": {
+          "name": "group_message_sender_idx",
+          "columns": ["sender_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "group_message_group_id_group_id_fk": {
+          "name": "group_message_group_id_group_id_fk",
+          "tableFrom": "group_message",
+          "tableTo": "group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_message_sender_id_user_id_fk": {
+          "name": "group_message_sender_id_user_id_fk",
+          "tableFrom": "group_message",
+          "tableTo": "user",
+          "columnsFrom": ["sender_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_message_reply_to_message_id_group_message_id_fk": {
+          "name": "group_message_reply_to_message_id_group_message_id_fk",
+          "tableFrom": "group_message",
+          "tableTo": "group_message",
+          "columnsFrom": ["reply_to_message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group_member": {
+      "name": "group_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "group_member_group_user_uidx": {
+          "name": "group_member_group_user_uidx",
+          "columns": ["group_id", "user_id"],
+          "isUnique": true
+        },
+        "group_member_group_created_idx": {
+          "name": "group_member_group_created_idx",
+          "columns": ["group_id", "created_at"],
+          "isUnique": false
+        },
+        "group_member_user_created_idx": {
+          "name": "group_member_user_created_idx",
+          "columns": ["user_id", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "group_member_group_id_group_id_fk": {
+          "name": "group_member_group_id_group_id_fk",
+          "tableFrom": "group_member",
+          "tableTo": "group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_member_user_id_user_id_fk": {
+          "name": "group_member_user_id_user_id_fk",
+          "tableFrom": "group_member",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group_pending": {
+      "name": "group_pending",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "group_pending_group_user_uidx": {
+          "name": "group_pending_group_user_uidx",
+          "columns": ["group_id", "user_id"],
+          "isUnique": true
+        },
+        "group_pending_group_created_idx": {
+          "name": "group_pending_group_created_idx",
+          "columns": ["group_id", "created_at"],
+          "isUnique": false
+        },
+        "group_pending_user_created_idx": {
+          "name": "group_pending_user_created_idx",
+          "columns": ["user_id", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "group_pending_group_id_group_id_fk": {
+          "name": "group_pending_group_id_group_id_fk",
+          "tableFrom": "group_pending",
+          "tableTo": "group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_pending_user_id_user_id_fk": {
+          "name": "group_pending_user_id_user_id_fk",
+          "tableFrom": "group_pending",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group": {
+      "name": "group",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_norm": {
+          "name": "tag_norm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accent": {
+          "name": "accent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_tag_norm_uidx": {
+          "name": "group_tag_norm_uidx",
+          "columns": ["tag_norm"],
+          "isUnique": true
+        },
+        "group_creator_idx": {
+          "name": "group_creator_idx",
+          "columns": ["creator_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "group_creator_id_user_id_fk": {
+          "name": "group_creator_id_user_id_fk",
+          "tableFrom": "group",
+          "tableTo": "user",
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "message_reply": {
+      "name": "message_reply",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_sender": {
+          "name": "from_sender",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "message_reply_message_created_id_idx": {
+          "name": "message_reply_message_created_id_idx",
+          "columns": ["message_id", "created_at", "id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_reply_message_id_message_id_fk": {
+          "name": "message_reply_message_id_message_id_fk",
+          "tableFrom": "message_reply",
+          "tableTo": "message",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "message": {
+      "name": "message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reply": {
+          "name": "reply",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_reply_at": {
+          "name": "last_reply_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_read_at": {
+          "name": "sender_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "receiver_read_at": {
+          "name": "receiver_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "receiver_id_created_at_id_idx": {
+          "name": "receiver_id_created_at_id_idx",
+          "columns": ["receiver_id", "created_at", "id"],
+          "isUnique": false
+        },
+        "sender_id_created_at_id_idx": {
+          "name": "sender_id_created_at_id_idx",
+          "columns": ["sender_id", "created_at", "id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "note_reaction": {
+      "name": "note_reaction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "note_reaction_note_user_uidx": {
+          "name": "note_reaction_note_user_uidx",
+          "columns": ["note_id", "user_id"],
+          "isUnique": true
+        },
+        "note_reaction_user_note_idx": {
+          "name": "note_reaction_user_note_idx",
+          "columns": ["user_id", "note_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "note_reaction_note_id_note_id_fk": {
+          "name": "note_reaction_note_id_note_id_fk",
+          "tableFrom": "note_reaction",
+          "tableTo": "note",
+          "columnsFrom": ["note_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_reaction_user_id_user_id_fk": {
+          "name": "note_reaction_user_id_user_id_fk",
+          "tableFrom": "note_reaction",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "note": {
+      "name": "note",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reaction_count": {
+          "name": "reaction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "music_provider": {
+          "name": "music_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "music_id": {
+          "name": "music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "music_title": {
+          "name": "music_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "music_thumbnail": {
+          "name": "music_thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spotify_track_id": {
+          "name": "spotify_track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spotify_title": {
+          "name": "spotify_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spotify_thumbnail": {
+          "name": "spotify_thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "note_user_id_unique": {
+          "name": "note_user_id_unique",
+          "columns": ["user_id"],
+          "isUnique": true
+        },
+        "updated_at_id_idx": {
+          "name": "updated_at_id_idx",
+          "columns": ["updated_at", "id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification": {
+      "name": "notification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "preview": {
+          "name": "preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "notification_recipient_type_target_uidx": {
+          "name": "notification_recipient_type_target_uidx",
+          "columns": ["recipient_id", "type", "target_id"],
+          "isUnique": true
+        },
+        "notification_recipient_updated_id_idx": {
+          "name": "notification_recipient_updated_id_idx",
+          "columns": ["recipient_id", "updated_at", "id"],
+          "isUnique": false
+        },
+        "notification_updated_idx": {
+          "name": "notification_updated_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notification_recipient_id_user_id_fk": {
+          "name": "notification_recipient_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": ["recipient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_actor_id_user_id_fk": {
+          "name": "notification_actor_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "poll_option": {
+      "name": "poll_option",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "poll_option_post_idx_uidx": {
+          "name": "poll_option_post_idx_uidx",
+          "columns": ["post_id", "idx"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "poll_option_post_id_postTable_id_fk": {
+          "name": "poll_option_post_id_postTable_id_fk",
+          "tableFrom": "poll_option",
+          "tableTo": "postTable",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "poll_vote": {
+      "name": "poll_vote",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "poll_vote_post_user_uidx": {
+          "name": "poll_vote_post_user_uidx",
+          "columns": ["post_id", "user_id"],
+          "isUnique": true
+        },
+        "poll_vote_user_post_idx": {
+          "name": "poll_vote_user_post_idx",
+          "columns": ["user_id", "post_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "poll_vote_post_id_postTable_id_fk": {
+          "name": "poll_vote_post_id_postTable_id_fk",
+          "tableFrom": "poll_vote",
+          "tableTo": "postTable",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "poll_vote_option_id_poll_option_id_fk": {
+          "name": "poll_vote_option_id_poll_option_id_fk",
+          "tableFrom": "poll_vote",
+          "tableTo": "poll_option",
+          "columnsFrom": ["option_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "poll_vote_user_id_user_id_fk": {
+          "name": "poll_vote_user_id_user_id_fk",
+          "tableFrom": "poll_vote",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_comment_like": {
+      "name": "post_comment_like",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "post_comment_like_comment_user_uidx": {
+          "name": "post_comment_like_comment_user_uidx",
+          "columns": ["comment_id", "user_id"],
+          "isUnique": true
+        },
+        "post_comment_like_user_created_idx": {
+          "name": "post_comment_like_user_created_idx",
+          "columns": ["user_id", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_comment_like_comment_id_post_comment_id_fk": {
+          "name": "post_comment_like_comment_id_post_comment_id_fk",
+          "tableFrom": "post_comment_like",
+          "tableTo": "post_comment",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comment_like_user_id_user_id_fk": {
+          "name": "post_comment_like_user_id_user_id_fk",
+          "tableFrom": "post_comment_like",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_comment": {
+      "name": "post_comment",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "post_comment_post_created_idx": {
+          "name": "post_comment_post_created_idx",
+          "columns": ["post_id", "created_at", "id"],
+          "isUnique": false
+        },
+        "post_comment_author_created_idx": {
+          "name": "post_comment_author_created_idx",
+          "columns": ["author_id", "created_at", "id"],
+          "isUnique": false
+        },
+        "post_comment_post_author_idx": {
+          "name": "post_comment_post_author_idx",
+          "columns": ["post_id", "author_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_comment_post_id_postTable_id_fk": {
+          "name": "post_comment_post_id_postTable_id_fk",
+          "tableFrom": "post_comment",
+          "tableTo": "postTable",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comment_author_id_user_id_fk": {
+          "name": "post_comment_author_id_user_id_fk",
+          "tableFrom": "post_comment",
+          "tableTo": "user",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_like": {
+      "name": "post_like",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "post_like_post_user_uidx": {
+          "name": "post_like_post_user_uidx",
+          "columns": ["post_id", "user_id"],
+          "isUnique": true
+        },
+        "post_like_user_created_idx": {
+          "name": "post_like_user_created_idx",
+          "columns": ["user_id", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_like_post_id_postTable_id_fk": {
+          "name": "post_like_post_id_postTable_id_fk",
+          "tableFrom": "post_like",
+          "tableTo": "postTable",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_like_user_id_user_id_fk": {
+          "name": "post_like_user_id_user_id_fk",
+          "tableFrom": "post_like",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_repost": {
+      "name": "post_repost",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "post_repost_post_user_uidx": {
+          "name": "post_repost_post_user_uidx",
+          "columns": ["post_id", "user_id"],
+          "isUnique": true
+        },
+        "post_repost_user_created_idx": {
+          "name": "post_repost_user_created_idx",
+          "columns": ["user_id", "created_at"],
+          "isUnique": false
+        },
+        "post_repost_post_created_idx": {
+          "name": "post_repost_post_created_idx",
+          "columns": ["post_id", "created_at"],
+          "isUnique": false
+        },
+        "post_repost_created_idx": {
+          "name": "post_repost_created_idx",
+          "columns": ["created_at", "id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_repost_post_id_postTable_id_fk": {
+          "name": "post_repost_post_id_postTable_id_fk",
+          "tableFrom": "post_repost",
+          "tableTo": "postTable",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_repost_user_id_user_id_fk": {
+          "name": "post_repost_user_id_user_id_fk",
+          "tableFrom": "post_repost",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "postTable": {
+      "name": "postTable",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "images": {
+          "name": "images",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quoted_post_id": {
+          "name": "quoted_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "repost_count": {
+          "name": "repost_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "poll_vote_count": {
+          "name": "poll_vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "poll_ends_at": {
+          "name": "poll_ends_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_created_at_id_idx": {
+          "name": "post_created_at_id_idx",
+          "columns": ["created_at", "id"],
+          "isUnique": false
+        },
+        "post_author_created_at_idx": {
+          "name": "post_author_created_at_idx",
+          "columns": ["author_id", "created_at", "id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "postTable_author_id_user_id_fk": {
+          "name": "postTable_author_id_user_id_fk",
+          "tableFrom": "postTable",
+          "tableTo": "user",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pro_purchase": {
+      "name": "pro_purchase",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_mode": {
+          "name": "test_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "pro_purchase_order_uidx": {
+          "name": "pro_purchase_order_uidx",
+          "columns": ["order_id"],
+          "isUnique": true
+        },
+        "pro_purchase_user_idx": {
+          "name": "pro_purchase_user_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pro_purchase_user_id_user_id_fk": {
+          "name": "pro_purchase_user_id_user_id_fk",
+          "tableFrom": "pro_purchase",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "push_subscription": {
+      "name": "push_subscription",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_notified_at": {
+          "name": "last_notified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "push_subscription_endpoint_uidx": {
+          "name": "push_subscription_endpoint_uidx",
+          "columns": ["endpoint"],
+          "isUnique": true
+        },
+        "push_subscription_user_idx": {
+          "name": "push_subscription_user_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "push_subscription_last_notified_idx": {
+          "name": "push_subscription_last_notified_idx",
+          "columns": ["last_notified_at"],
+          "isUnique": false,
+          "where": "\"push_subscription\".\"last_notified_at\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "push_subscription_user_id_user_id_fk": {
+          "name": "push_subscription_user_id_user_id_fk",
+          "tableFrom": "push_subscription",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_account": {
+      "name": "oauth_account",
+      "columns": {
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_account_user_idx": {
+          "name": "oauth_account_user_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "session_expires_idx": {
+          "name": "session_expires_idx",
+          "columns": ["expires_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_block": {
+      "name": "user_block",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "user_block_blocker_blocked_uidx": {
+          "name": "user_block_blocker_blocked_uidx",
+          "columns": ["blocker_id", "blocked_id"],
+          "isUnique": true
+        },
+        "user_block_blocker_created_idx": {
+          "name": "user_block_blocker_created_idx",
+          "columns": ["blocker_id", "created_at"],
+          "isUnique": false
+        },
+        "user_block_blocked_created_idx": {
+          "name": "user_block_blocked_created_idx",
+          "columns": ["blocked_id", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_block_blocker_id_user_id_fk": {
+          "name": "user_block_blocker_id_user_id_fk",
+          "tableFrom": "user_block",
+          "tableTo": "user",
+          "columnsFrom": ["blocker_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_block_blocked_id_user_id_fk": {
+          "name": "user_block_blocked_id_user_id_fk",
+          "tableFrom": "user_block",
+          "tableTo": "user",
+          "columnsFrom": ["blocked_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_follow": {
+      "name": "user_follow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "user_follow_follower_following_uidx": {
+          "name": "user_follow_follower_following_uidx",
+          "columns": ["follower_id", "following_id"],
+          "isUnique": true
+        },
+        "user_follow_follower_created_idx": {
+          "name": "user_follow_follower_created_idx",
+          "columns": ["follower_id", "created_at"],
+          "isUnique": false
+        },
+        "user_follow_following_created_idx": {
+          "name": "user_follow_following_created_idx",
+          "columns": ["following_id", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_follow_follower_id_user_id_fk": {
+          "name": "user_follow_follower_id_user_id_fk",
+          "tableFrom": "user_follow",
+          "tableTo": "user",
+          "columnsFrom": ["follower_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_follow_following_id_user_id_fk": {
+          "name": "user_follow_following_id_user_id_fk",
+          "tableFrom": "user_follow",
+          "tableTo": "user",
+          "columnsFrom": ["following_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banner_image_url": {
+          "name": "banner_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quiet_mode": {
+          "name": "quiet_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Send me an anonymous message!'"
+        },
+        "blocked_words": {
+          "name": "blocked_words",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_post_id": {
+          "name": "pinned_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "equipped_group_id": {
+          "name": "equipped_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "follower_count": {
+          "name": "follower_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "following_count": {
+          "name": "following_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pro_until": {
+          "name": "pro_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_theme": {
+          "name": "profile_theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "push_prefs": {
+          "name": "push_prefs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_seen_notifications_at": {
+          "name": "last_seen_notifications_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned_by": {
+          "name": "banned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "music_provider": {
+          "name": "music_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "music_id": {
+          "name": "music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "music_title": {
+          "name": "music_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "music_thumbnail": {
+          "name": "music_thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": ["username"],
+          "isUnique": true
+        },
+        "user_equipped_group_idx": {
+          "name": "user_equipped_group_idx",
+          "columns": ["equipped_group_id"],
+          "isUnique": false,
+          "where": "\"user\".\"equipped_group_id\" IS NOT NULL"
+        },
+        "user_banned_idx": {
+          "name": "user_banned_idx",
+          "columns": ["banned_at"],
+          "isUnique": false,
+          "where": "\"user\".\"banned_at\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1786081997525,
       "tag": "0024_majestic_proteus",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "6",
+      "when": 1788241392442,
+      "tag": "0025_noisy_night_thrasher",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/notification.ts
+++ b/packages/db/src/schema/notification.ts
@@ -75,6 +75,9 @@ export const notificationTable = sqliteTable(
       t.updatedAt,
       t.id,
     ),
+    // Backs the nightly retention sweep (DELETE WHERE updated_at < cutoff); the
+    // recipient-leading composite above can't serve a global range.
+    index("notification_updated_idx").on(t.updatedAt),
   ],
 );
 

--- a/packages/db/src/schema/user.ts
+++ b/packages/db/src/schema/user.ts
@@ -117,9 +117,14 @@ export const sessionTable = sqliteTable(
       .references(() => userTable.id, { onDelete: "cascade" }),
     expiresAt: integer("expires_at").notNull(),
   },
-  // Backs DELETE ... WHERE user_id = ? (password-change session revocation) and
-  // the user-delete FK cascade lookup.
-  (t) => [index("session_user_idx").on(t.userId)],
+  (t) => [
+    // Backs DELETE ... WHERE user_id = ? (password-change session revocation)
+    // and the user-delete FK cascade lookup.
+    index("session_user_idx").on(t.userId),
+    // Backs the nightly expired-session sweep (DELETE WHERE expires_at < now),
+    // which would otherwise scan the whole table — Turso bills per row scanned.
+    index("session_expires_idx").on(t.expiresAt),
+  ],
 );
 
 export const sessionRelations = relations(sessionTable, ({ one }) => ({

--- a/packages/encryption/src/index.test.ts
+++ b/packages/encryption/src/index.test.ts
@@ -71,6 +71,28 @@ describe("aesEncrypt / aesDecrypt", () => {
     );
   });
 
+  // The imported CryptoKey is cached per raw key string. If the cache ignored
+  // the string it would serve the first key forever: the swapped-key round trip
+  // would still "work" and the old payload would still decrypt.
+  it("re-imports when AES_256_GCM_KEY changes", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const original = process.env.AES_256_GCM_KEY;
+    const underOriginal = await aesEncrypt("before swap");
+
+    try {
+      process.env.AES_256_GCM_KEY = await generateBase64Key();
+      const underSecond = await aesEncrypt("after swap");
+      expect(await aesDecrypt(underSecond)).toBe("after swap");
+      // The first key's payload must no longer authenticate.
+      await expect(aesDecrypt(underOriginal)).rejects.toThrow();
+    } finally {
+      process.env.AES_256_GCM_KEY = original;
+    }
+
+    // Swapping back restores the original key, not a stale cached one.
+    expect(await aesDecrypt(underOriginal)).toBe("before swap");
+  });
+
   it("throws when the AES key env var is absent", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     const original = process.env.AES_256_GCM_KEY;

--- a/packages/encryption/src/index.ts
+++ b/packages/encryption/src/index.ts
@@ -32,6 +32,26 @@ async function importAesKey(base64Key: string): Promise<CryptoKey> {
   );
 }
 
+// The env key never changes within an isolate, and a message page decrypts
+// dozens of rows — re-importing per call was the largest avoidable CPU cost on
+// encrypted read paths. Keyed on the raw string so a swapped key still applies.
+let cachedKey: { raw: string; key: Promise<CryptoKey> } | null = null;
+
+function getCachedAesKey(): Promise<CryptoKey> {
+  const raw = getAesKeyFromEnv();
+  if (!cachedKey || cachedKey.raw !== raw) {
+    cachedKey = {
+      raw,
+      // A rejected import must not stay pinned in the cache.
+      key: importAesKey(raw).catch((err) => {
+        cachedKey = null;
+        throw err;
+      }),
+    };
+  }
+  return cachedKey.key;
+}
+
 function splitPayload(payload: string): {
   cipherText: Uint8Array;
   iv: Uint8Array;
@@ -46,8 +66,7 @@ function splitPayload(payload: string): {
 
 export async function aesEncrypt(plainText: string): Promise<string> {
   try {
-    const rawBase64 = getAesKeyFromEnv();
-    const key = await importAesKey(rawBase64);
+    const key = await getCachedAesKey();
 
     const enc = new TextEncoder();
 
@@ -73,8 +92,7 @@ export async function aesEncrypt(plainText: string): Promise<string> {
 
 export async function aesDecrypt(payload: string): Promise<string> {
   try {
-    const rawBase64 = getAesKeyFromEnv();
-    const key = await importAesKey(rawBase64);
+    const key = await getCachedAesKey();
 
     const { cipherText: ctGen, iv: ivGen } = splitPayload(payload);
 


### PR DESCRIPTION
Overall optimization pass over `apps/web` (TanStack Start + Hono on one Worker): closes the PostHog error-tracking blind spots, hardens the reporter itself, and cuts Turso round trips on the hottest read/write paths. Eight commits, each independently reviewable.

## Observability

- **`80ca42ce`** — the reporter can no longer throw into a handled catch (`waitUntil` + URL parse guarded); `withPublicRead`'s cache lookup degrades to a miss instead of a 500 and its `cache.put` is rejection-safe; SSR loader dispatches now forward to the real `ExecutionContext`, so error reports (and cache puts) from SSR reads stop being dropped with the isolate.
- **`230454ca`** — capture at every server surface that sat outside the four chokepoints: login/signup/delete-account, the Google OAuth callback (which logged a bare string with no error), the Lemon Squeezy paid-but-dropped branches (foreign store / unattributed / missing secret — the `200` no-retry contract unchanged), checkout creation, `notify()` + Web Push fan-out (VAPID 401/403 and unknown throws only), flag-evaluation failures (fail-closed behavior unchanged), and the profile read. Read-wrapper reports now carry the viewer's id as `distinctId`.
- **`6346ea3d`** — client side: `MutationCache.onError`, transport failures in `callAction`, all 20 `catch { console.log(err) }` sites now capture, share/clipboard promises are awaited (no more false "copied" toasts; dismissed share sheets no longer mint AbortError issues), and the viewer id is stamped via `posthog.register` (never `identify` — no billable person profiles).

## Performance

- **`e7e43b95`** — one like no longer re-renders every loaded feed card: identity-preserving cache patch + `useMemo` + `memo(PostCard)`.
- **`65ea5b03`** — the AES-GCM `CryptoKey` is imported once per isolate instead of per encrypt/decrypt call (a thread read did up to ~200 imports).
- **`9508f8a6`** — indexes for the nightly cleanup sweeps (`session.expires_at`, `notification.updated_at`); both DELETEs verified `SCAN` → `SEARCH` via local `EXPLAIN QUERY PLAN`. Additive migration `0025`, auto-applies via `migrate.yml`.
- **`1e6d79ce`** — `prefetch={false}` was silently swallowed by the nav shim; mentions and group badges now actually disable hover-preload. Flags evaluation reuses one PostHog client per isolate.
- **`db6da404`** — six chained-round-trip cuts (profile double-fetch, pin lookup, quoted-author join, quoted-post overlay fold, push fan-out `Promise.all`) plus parallelized post-detail and group-page loaders. Each ~80–160 ms off a hot path; result sets unchanged (existing suites pass with zero assertion edits).
- **`7b73673a`** — like/unlike collapse from ~4 chained Tokyo round trips to one `db.batch`, with the JS branching moved into SQL via `changes()` gating. The semantics are pinned by a new characterization test (`test/batch-changes.test.ts`) that doubles as the regression guard for driver bumps. Response envelopes and aura guards unchanged.
- **`17d93ffc`** — signed-in feed/post/comments/notes reads now share the public route's Cache API entry and apply the per-viewer overlay on top: a warm signed-in feed read drops from ~4–5 chained Turso hops to 1, and signed-in traffic warms the cache for anonymous traffic (and vice versa). Leak guards (`caches.default` only in `read-route.ts`, overlay never cached, no Set-Cookie, null never stored) are pinned by 7 new worker tests. Also fixes a cache-key traversal: the `:id` segment is re-encoded so a crafted id can't normalize onto another route's entry.

## Tradeoffs / deploy notes

- Signed-in readers now see counts/content up to the public TTL stale (180s feed / 120s post) — the same window anonymous readers already accept. Own actions stay instant via optimistic patches, and the viewer overlay (isLiked/isReposted/blocks) is always fresh.
- Push fan-out reads run in parallel, so opted-out users pay two extra parallel reads that the old short-circuit skipped (no added wall-clock).
- Worth one staging smoke after deploy: group page roster renders without a client waterfall (loader now primes viewer + members), and settings/tiers load normally.
- Follow-ups deliberately not in this PR: a `getFeedCursorCondition` rewrite (an EXPLAIN investigation found the public-latest feed's deep-page cursor degrades to an O(offset) index scan — verified row-value fix sketched, ~90x faster at depth, byte-identical results), the correctness fixes for delete-account/sign-out false-success envelopes, and a PostHog alert on the "unattributed paid order" issue.

## Test plan

- `pnpm --filter=web check-types` / `pnpm --filter=@umamin/db check-types` — clean
- `pnpm --filter=web test` — 376 passed (was 358; new suites: client-capture, query-cache identity, batch-changes, data-post block husks)
- `pnpm --filter=web test:workers` — 127 passed (new: cached-public-payload leak guards)
- `pnpm --filter=@umamin/encryption test` — 7 passed (new: key-swap round-trip)
- Migration validated locally against a temp libSQL db (`EXPLAIN QUERY PLAN` before/after)